### PR TITLE
Disabling conformance_tests on Mac

### DIFF
--- a/UnitTest/test_main.cpp
+++ b/UnitTest/test_main.cpp
@@ -22,7 +22,11 @@ THE SOFTWARE.
 #include "clw_test.h"
 #include "clw_cl_test.h"
 #include "firerays_test.h"
+// TODO: CPU on Apple is not supported because Apple doesn't allow creation of
+// work group size > 1 on CPU devices, see CLW/CLWPlatform.cpp. So disabling the test.
+#ifndef __APPLE__
 #include "firerays_conformance_test.h"
+#endif
 #include "firerays_cl_test.h"
 #include "calc_test_cl.h"
 


### PR DESCRIPTION
CLWPlatform doesn't enumerate Mac's CPU as OpenCL device because
Mac OS doesn't allow creation of work group with 1+ devices if CPU
is there as well.
