### PR TITLE
Fix std::string not declared error.

### DIFF
--- a/App/Light/Ibl.h
+++ b/App/Light/Ibl.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <string>
 
 namespace Baikal
 {


### PR DESCRIPTION
Under Ubuntu Linux 16.04LTS, I got a compilation error:

Ibl.cpp
In file included from Light/Ibl.cpp:1:0:
./Light/Ibl.h:36:27: error: ‘std::string’ has not been declared
         void DumpPdf(std::string const& filename);

The fix was simply include <string> inside Ibl.h.
