### PR TITLE
Update CLWPlatform.cpp

### DIFF
--- a/CLW/CLWPlatform.cpp
+++ b/CLW/CLWPlatform.cpp
@@ -70,7 +70,7 @@ void CLWPlatform::CreateAllPlatforms(std::vector<CLWPlatform>& platforms)
 
         std::string versionstr(version.begin(), version.end());
 
-        if (versionstr.find("OpenCL 1.0") != std::string::npos ||
+        if (versionstr.find("OpenCL 1.0 ") != std::string::npos ||
             versionstr.find("OpenCL 1.1") != std::string::npos)
         {
             continue;


### PR DESCRIPTION
Application failed to detect the OpenCL platform in case the opencl version having like this from clinfo application
"Platform Version: OpenCL 2.0                               AMD-APP (2431.0)" . 

Adding extra space at the end of if statement  like "1.0 " would solve this problem.