### PR TITLE
Update to the latest Embree version

### DIFF
--- a/RadeonRays/src/device/embree_intersection_device.cpp
+++ b/RadeonRays/src/device/embree_intersection_device.cpp
@@ -116,7 +116,7 @@ namespace RadeonRays
         if (result != RTC_NO_ERROR)
             std::cout << "Failed to create embree rtcDevice: " << result << std::endl;
 
-        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECTN);
+        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM);
         result = rtcDeviceGetError(m_device);
         if (result != RTC_NO_ERROR)
             std::cout << "Failed to create embree scene: " << result << std::endl;
@@ -171,7 +171,7 @@ namespace RadeonRays
         }
         m_instances.clear();
         rtcDeleteScene(m_scene); CheckEmbreeError();
-        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECTN); CheckEmbreeError();
+        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM); CheckEmbreeError();
 
         for (auto i : world.shapes_)
         {
@@ -500,7 +500,7 @@ namespace RadeonRays
     {
         if (m_meshes.count(mesh))
             return m_meshes[mesh].scene;
-        RTCScene result = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECTN);
+        RTCScene result = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM);
         CheckEmbreeError();
         ThrowIf(!mesh->puretriangle(), "Only triangle meshes supported by now.");
 


### PR DESCRIPTION
This is an update to allow RadeonRays to build with the current version of Embree. RTC_INTERSECTN was replace by RTC_INTERSECT_STREAM a while ago:
https://github.com/embree/embree/commit/e30bbe89e3addf471c3212948e19864fe1ccf077