### PR TITLE
Fix for missing def and switching to only allowing GPU devices

### DIFF
--- a/CLW/CLW.lua
+++ b/CLW/CLW.lua
@@ -14,6 +14,10 @@ project "CLW"
 
     configuration {}
 
+	if _OPTIONS["allow_cpu_devices"] then
+        defines {"RR_ALLOW_CPU_DEVICES=1"}
+	end
+	
     -- we rely on RadeonRays to do the actual embedding for us
     if _OPTIONS["embed_kernels"] then
         defines {"RR_EMBED_KERNELS=1"}

--- a/CLW/CLWPlatform.cpp
+++ b/CLW/CLWPlatform.cpp
@@ -48,7 +48,12 @@ void CLWPlatform::CreateAllPlatforms(std::vector<CLWPlatform>& platforms)
     status = clGetPlatformIDs(numPlatforms, &platformIds[0], nullptr);
     ThrowIf(status != CL_SUCCESS, status, "clGetPlatformIDs failed");
 
-    cl_device_type type = CL_DEVICE_TYPE_ALL;
+
+#ifdef RR_ALLOW_CPU_DEVICES
+	cl_device_type type = CL_DEVICE_TYPE_ALL;
+#else
+	cl_device_type type = CL_DEVICE_TYPE_GPU;
+#endif
 
     // TODO: this is a workaround for nasty Apple's OpenCL runtime
     // which doesn't allow to have work group sizes > 1 on CPU devices

--- a/RadeonRays/src/device/embree_intersection_device.cpp
+++ b/RadeonRays/src/device/embree_intersection_device.cpp
@@ -116,7 +116,7 @@ namespace RadeonRays
         if (result != RTC_NO_ERROR)
             std::cout << "Failed to create embree rtcDevice: " << result << std::endl;
 
-        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM);
+        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 );
         result = rtcDeviceGetError(m_device);
         if (result != RTC_NO_ERROR)
             std::cout << "Failed to create embree scene: " << result << std::endl;
@@ -171,7 +171,7 @@ namespace RadeonRays
         }
         m_instances.clear();
         rtcDeleteScene(m_scene); CheckEmbreeError();
-        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM); CheckEmbreeError();
+        m_scene = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 ); CheckEmbreeError();
 
         for (auto i : world.shapes_)
         {
@@ -500,7 +500,7 @@ namespace RadeonRays
     {
         if (m_meshes.count(mesh))
             return m_meshes[mesh].scene;
-        RTCScene result = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 | RTC_INTERSECT_STREAM);
+        RTCScene result = rtcDeviceNewScene(m_device, RTC_SCENE_STATIC, RTC_INTERSECT1 | RTC_INTERSECT4 | RTC_INTERSECT8 | RTC_INTERSECT16 );
         CheckEmbreeError();
         ThrowIf(!mesh->puretriangle(), "Only triangle meshes supported by now.");
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -9,6 +9,11 @@ newoption {
 }
 
 newoption {
+    trigger     = "allow_cpu_devices",
+    description = "Allows CPU Devices"
+}
+
+newoption {
     trigger = "use_opencl",
     description = "Use OpenCL for GPU hit testing"
 }


### PR DESCRIPTION
Fixed embree flag that doesnt exist anymore

Switched to default to discrete GPU only and added the option to allow CPU.