### PR TITLE
Case update for tools include in tutorials

### DIFF
--- a/Tutorials/CornellBox/main.cpp
+++ b/Tutorials/CornellBox/main.cpp
@@ -25,8 +25,8 @@ THE SOFTWARE.
 #include <cassert>
 #include <iostream>
 #include <memory>
-#include "../tools/shader_manager.h"
-#include "../tools/tiny_obj_loader.h"
+#include "../Tools/shader_manager.h"
+#include "../Tools/tiny_obj_loader.h"
 
 using namespace RadeonRays;
 using namespace tinyobj;
@@ -208,7 +208,7 @@ int main(int argc, char* argv[])
         api->AttachShape(shape);
         shape->SetId(id);
     }
-    // Ñommit scene changes
+    // Commit scene changes
     api->Commit();
 
     const int k_raypack_size = g_window_height * g_window_width;

--- a/Tutorials/CornellBoxShadow/main.cpp
+++ b/Tutorials/CornellBoxShadow/main.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include <cassert>
 #include <iostream>
 #include <memory>
-#include "../tools/shader_manager.h"
-#include "../tools/tiny_obj_loader.h"
+#include "../Tools/shader_manager.h"
+#include "../Tools/tiny_obj_loader.h"
 
 using namespace RadeonRays;
 using namespace tinyobj;
@@ -372,7 +372,7 @@ int main(int argc, char* argv[])
         g_api->AttachShape(shape);
         shape->SetId(id);
     }
-    // Ñommit scene changes
+    // Commit scene changes
     g_api->Commit();
 
     const int k_raypack_size = g_window_height * g_window_width;

--- a/Tutorials/Triangle/main.cpp
+++ b/Tutorials/Triangle/main.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <cassert>
 #include <iostream>
 #include <memory>
-#include "../tools/shader_manager.h"
+#include "../Tools/shader_manager.h"
 
 using namespace RadeonRays;
 

--- a/Tutorials/TriangleLight/main.cpp
+++ b/Tutorials/TriangleLight/main.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <cassert>
 #include <iostream>
 #include <memory>
-#include "../tools/shader_manager.h"
+#include "../Tools/shader_manager.h"
 
 using namespace RadeonRays;
 


### PR DESCRIPTION
This PR removes warning `non-portable path to file '"../Tools/shader_manager.h"'`in tutorials