### PR TITLE
Fix a configuration error on macosx with --use_vulkan --embed_kernels

### DIFF
--- a/RadeonRays/RadeonRays.lua
+++ b/RadeonRays/RadeonRays.lua
@@ -72,7 +72,7 @@ project "RadeonRays"
 
         if _OPTIONS["use_vulkan"] then
             os.execute( "python ../Tools/scripts/stringify.py " ..
-                                os.getcwd() .. "./../RadeonRays/src/kernels/GLSL/ "  ..
+                                os.getcwd() .. "/../RadeonRays/src/kernels/GLSL/ "  ..
                                 ".comp " ..
                                 "vulkan " ..
                                  "> ./src/kernelcache/kernels_vk.h"


### PR DESCRIPTION
The configuration error is like this: there is an extra dot in a path that prevents python to find files.
 
    me:~/RadeonRays_SDK$ ./Tools/premake/osx/premake5 --use_vulkan --embed_kernels
    >> Vulkan backend enabled
    ** Warning: the flags value Symbols has been deprecated.
    Use `symbols "On"` instead
    Traceback (most recent call last):
    File "../Tools/scripts/stringify.py", line 29, in <module>
        files = os.listdir(dir)
    OSError: [Errno 2] No such file or directory: '/Users/me/RadeonRays_SDK/RadeonRays./../RadeonRays/src/kernels/GLSL/'
    >> RadeonRays: VK kernels embedded
    Type 'premake5 --help' for help