### PR TITLE
Fixed instance rendering with bvh2

### DIFF
--- a/RadeonRays/src/accelerator/bvh2.h
+++ b/RadeonRays/src/accelerator/bvh2.h
@@ -29,6 +29,10 @@ THE SOFTWARE.
 #include "../primitive/mesh.h"
 #include "../primitive/instance.h"
 
+#ifndef WIN32
+#define _MM_ALIGN16
+#endif
+
 namespace RadeonRays
 {
 

--- a/RadeonRays/src/accelerator/bvh2.h
+++ b/RadeonRays/src/accelerator/bvh2.h
@@ -334,8 +334,8 @@ namespace RadeonRays
     {
         auto shape = ref.first;
         matrix worldmat, worldmatinv;
+        shape->GetTransform(worldmat, worldmatinv);
         auto mesh = static_cast<const Mesh *>(static_cast<const ShapeImpl *>(shape)->is_instance() ? static_cast<const Instance *>(shape)->GetBaseShape() : shape);
-        mesh->GetTransform(worldmat, worldmatinv);
         auto face = mesh->GetFaceData()[ref.second];
         auto v0 = transform_point(mesh->GetVertexData()[face.idx[0]], worldmat);
         auto v1 = transform_point(mesh->GetVertexData()[face.idx[1]], worldmat);

--- a/RadeonRays/src/device/calc_intersection_device.cpp
+++ b/RadeonRays/src/device/calc_intersection_device.cpp
@@ -126,7 +126,7 @@ namespace RadeonRays
                         m_intersector_string = "fatbvh";
 #else
                         m_intersector.reset(new IntersectorLDS(m_device.get()));
-                        m_intersector_string = "bvh2";
+                        m_intersector_string = "fatbvh";
 #endif
                     }
                 }

--- a/RadeonRays/src/kernelcache/kernels_cl.h
+++ b/RadeonRays/src/kernelcache/kernels_cl.h
@@ -2487,7 +2487,7 @@ static const char g_intersect_bvh2_lds_opencl[]= \
 " \n"\
 "#define GROUP_SIZE 64 \n"\
 "#define STACK_SIZE 32 \n"\
-"#define LDS_STACK_SIZE 8 \n"\
+"#define LDS_STACK_SIZE 16 \n"\
 " \n"\
 "// BVH node \n"\
 "typedef struct \n"\
@@ -2699,13 +2699,10 @@ static const char g_intersect_bvh2_lds_opencl[]= \
 "            const float3 invDir = safe_invdir(my_ray); \n"\
 "            const float3 oxInvDir = -my_ray.o.xyz * invDir; \n"\
 " \n"\
-"            // Intersection parametric distance \n"\
-"            float closest_t = my_ray.o.w; \n"\
-" \n"\
 "            // Current node address \n"\
 "            uint addr = 0; \n"\
-"            // Current closest address \n"\
-"            uint closest_addr = INVALID_ADDR; \n"\
+"            // Intersection parametric distance \n"\
+"            const float closest_t = my_ray.o.w; \n"\
 " \n"\
 "            uint stack_bottom = STACK_SIZE * index; \n"\
 "            uint sptr = stack_bottom; \n"\

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
@@ -34,7 +34,7 @@ TYPE DEFINITIONS
 
 #define GROUP_SIZE 64
 #define STACK_SIZE 32
-#define LDS_STACK_SIZE 8
+#define LDS_STACK_SIZE 16
 
 // BVH node
 typedef struct
@@ -246,13 +246,10 @@ KERNEL void occluded_main(
             const float3 invDir = safe_invdir(my_ray);
             const float3 oxInvDir = -my_ray.o.xyz * invDir;
 
-            // Intersection parametric distance
-            float closest_t = my_ray.o.w;
-
             // Current node address
             uint addr = 0;
-            // Current closest address
-            uint closest_addr = INVALID_ADDR;
+            // Intersection parametric distance
+            const float closest_t = my_ray.o.w;
 
             uint stack_bottom = STACK_SIZE * index;
             uint sptr = stack_bottom;


### PR DESCRIPTION
When setting the primitive info into the BVH node, I was using the ID of the mesh rather than the instance.
Fixed now.