### PR TITLE
New ray masking and backface culling implementation

### DIFF
--- a/CLW/CLWBuffer.h
+++ b/CLW/CLWBuffer.h
@@ -48,8 +48,8 @@ public:
     static CLWBuffer<T> Create(cl_context context, cl_mem_flags flags, size_t elementCount, void* data);
     static CLWBuffer<T> CreateFromClBuffer(cl_mem buffer);
 
-    CLWBuffer() : elementCount_(0){}
-    virtual ~CLWBuffer();
+    CLWBuffer() = default;
+    virtual ~CLWBuffer() = default;
     
     size_t GetElementCount() const { return elementCount_; }
     
@@ -70,7 +70,7 @@ private:
 
     CLWBuffer(cl_mem buffer, size_t elementCount);
 
-    size_t elementCount_;
+    size_t elementCount_ = 0;
     
     friend class CLWContext;
 };
@@ -120,10 +120,6 @@ template <typename T> CLWBuffer<T>::CLWBuffer(cl_mem buffer, size_t elementCount
 , elementCount_(elementCount)
 {
    
-}
-
-template <typename T> CLWBuffer<T>::~CLWBuffer()
-{
 }
 
 template <typename T> CLWEvent CLWBuffer<T>::WriteDeviceBuffer(CLWCommandQueue cmdQueue, T const* hostBuffer, size_t elemCount)

--- a/CLW/CLWCommandQueue.cpp
+++ b/CLW/CLWCommandQueue.cpp
@@ -54,15 +54,6 @@ CLWCommandQueue::CLWCommandQueue(cl_command_queue cmdQueue)
 {
 }
 
-CLWCommandQueue::CLWCommandQueue()
-{
-    
-}
-
-CLWCommandQueue::~CLWCommandQueue()
-{
-}
-
 #pragma warning(pop)
 
 

--- a/CLW/CLWCommandQueue.h
+++ b/CLW/CLWCommandQueue.h
@@ -43,9 +43,8 @@ public:
     static CLWCommandQueue Create(cl_command_queue queue);
     
     
-    CLWCommandQueue();
-    virtual          ~CLWCommandQueue();
-    
+    CLWCommandQueue() = default;
+    virtual ~CLWCommandQueue() = default;
     
     
 private:

--- a/CLW/CLWContext.cpp
+++ b/CLW/CLWContext.cpp
@@ -229,10 +229,6 @@ CLWContext::CLWContext(CLWDevice device)
     InitCL();
 }
 
-CLWContext::~CLWContext()
-{
-}
-
 unsigned int CLWContext::GetDeviceCount() const
 {
     return (unsigned int)devices_.size();
@@ -264,16 +260,15 @@ CLWImage2D CLWContext::CreateImage2DFromGLTexture(cl_GLint texture) const
 
 void CLWContext::AcquireGLObjects(unsigned int idx, std::vector<cl_mem> const& objects) const
 {
-    cl_int status = clEnqueueAcquireGLObjects(commandQueues_[idx], (cl_uint)objects.size(), &objects[0], 0,0,0);
+    cl_int status = clEnqueueAcquireGLObjects(commandQueues_[idx], (cl_uint)objects.size(), &objects[0], 0, nullptr, nullptr);
     ThrowIf(status != CL_SUCCESS, status, "clEnqueueAcquireGLObjects failed");
 }
 
 void CLWContext::ReleaseGLObjects(unsigned int idx, std::vector<cl_mem> const& objects) const
 {
-    cl_int status = clEnqueueReleaseGLObjects(commandQueues_[idx], (cl_uint)objects.size(), &objects[0], 0,0,0);
+    cl_int status = clEnqueueReleaseGLObjects(commandQueues_[idx], (cl_uint)objects.size(), &objects[0], 0, nullptr, nullptr);
     ThrowIf(status != CL_SUCCESS, status, "clEnqueueReleaseGLObjects failed");
 }
-
 
 void CLWContext::Finish(unsigned int idx) const
 {

--- a/CLW/CLWContext.h
+++ b/CLW/CLWContext.h
@@ -51,12 +51,12 @@ public:
     static CLWContext Create(cl_context context, cl_device_id* device, cl_command_queue* commandQueues, int numDevices);
     static CLWContext Create(CLWDevice device, cl_context_properties* props = nullptr);
 
-    CLWContext(){}
-    virtual                     ~CLWContext();
+    CLWContext() = default;
+    virtual ~CLWContext() = default;
 
-    unsigned int                GetDeviceCount() const;
-    CLWDevice                   GetDevice(unsigned int idx) const;
-    CLWProgram                  CreateProgram(std::vector<char> const& sourceCode, char const* buildopts = nullptr) const;
+    unsigned int GetDeviceCount() const;
+    CLWDevice GetDevice(unsigned int idx) const;
+    CLWProgram CreateProgram(std::vector<char> const& sourceCode, char const* buildopts = nullptr) const;
 
     template <typename T> CLWBuffer<T>  CreateBuffer(size_t elementCount, cl_mem_flags flags) const;
     template <typename T> CLWBuffer<T>  CreateBuffer(size_t elementCount, cl_mem_flags flags ,void* data) const;
@@ -205,8 +205,6 @@ template <typename T> CLWEvent  CLWContext::UnmapBuffer(unsigned int idx,  CLWBu
 {
     return buffer.UnmapDeviceBuffer(commandQueues_[idx], mappedData);
 }
-
-
 
 
 #endif /* defined(__CLW__CLWContext__) */

--- a/CLW/CLWDevice.cpp
+++ b/CLW/CLWDevice.cpp
@@ -44,10 +44,6 @@ CLWDevice::CLWDevice(cl_device_id id) : ReferenceCounter<cl_device_id, clRetainD
     GetDeviceInfoParameter(*this, CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE, minAlignSize_);
 }
 
-CLWDevice::~CLWDevice()
-{
-}
-
 template <> void CLWDevice::GetDeviceInfoParameter<std::string>(cl_device_id id, cl_device_info param, std::string& value)
 {
     size_t length = 0;

--- a/CLW/CLWDevice.h
+++ b/CLW/CLWDevice.h
@@ -43,8 +43,8 @@ class CLWDevice : public ReferenceCounter<cl_device_id, clRetainDevice, clReleas
 public:
     static CLWDevice Create(cl_device_id id);
     
-    CLWDevice(){}
-    virtual ~CLWDevice();
+    CLWDevice() = default;
+    virtual ~CLWDevice() = default;
 
     // Device info
     cl_ulong GetLocalMemSize() const;

--- a/CLW/CLWEvent.cpp
+++ b/CLW/CLWEvent.cpp
@@ -41,10 +41,6 @@ void CLWEvent::Wait()
     ThrowIf(status != CL_SUCCESS, status, "clWaitForEvents failed");
 }
 
-CLWEvent::~CLWEvent()
-{
-}
-
 float CLWEvent::GetDuration() const
 {
     cl_ulong commandStart, commandEnd;

--- a/CLW/CLWEvent.h
+++ b/CLW/CLWEvent.h
@@ -40,8 +40,8 @@ class CLWEvent : public ReferenceCounter<cl_event, clRetainEvent, clReleaseEvent
 {
 public:
     static CLWEvent Create(cl_event);
-    CLWEvent(){}
-    virtual      ~CLWEvent();
+    CLWEvent() = default;
+    virtual ~CLWEvent() = default;
 
     void  Wait();
     float GetDuration() const;

--- a/CLW/CLWImage2D.cpp
+++ b/CLW/CLWImage2D.cpp
@@ -74,8 +74,4 @@ CLWImage2D::CLWImage2D(cl_mem image)
 {
 }
 
-CLWImage2D::~CLWImage2D()
-{
-}
-
 #pragma warning(pop)

--- a/CLW/CLWImage2D.h
+++ b/CLW/CLWImage2D.h
@@ -47,8 +47,8 @@ public:
     static CLWImage2D Create(cl_context context, cl_image_format const* imgFormat, size_t width, size_t height, size_t rowPitch);
     static CLWImage2D CreateFromGLTexture(cl_context context, cl_GLint texture);
 
-    CLWImage2D(){}
-    virtual ~CLWImage2D();
+    CLWImage2D() = default;
+    virtual ~CLWImage2D() = default;
 
     operator ParameterHolder() const
     {

--- a/CLW/CLWKernel.h
+++ b/CLW/CLWKernel.h
@@ -39,8 +39,8 @@ class CLWKernel : public ReferenceCounter<cl_kernel, clRetainKernel, clReleaseKe
 public:
     static CLWKernel Create(cl_kernel kernel);
     /// to use in std::map
-    CLWKernel(){}
-    virtual ~CLWKernel(){}
+    CLWKernel() = default;
+    virtual ~CLWKernel() = default;
 
     virtual void SetArg(unsigned int idx, ParameterHolder param);
     virtual void SetArg(unsigned int idx, size_t size, void* ptr);

--- a/CLW/CLWParallelPrimitives.cpp
+++ b/CLW/CLWParallelPrimitives.cpp
@@ -813,7 +813,7 @@ CLWEvent CLWParallelPrimitives::SortRadix(unsigned int deviceIdx, CLWBuffer<cl_i
         context_.Launch1D(0, NUM_BLOCKS*WG_SIZE, WG_SIZE, histogramKernel);
 
         // Scan histograms
-        ScanExclusiveAdd(0, deviceHistograms, deviceHistograms, deviceHistograms.GetElementCount());
+        ScanExclusiveAdd(0, deviceHistograms, deviceHistograms, static_cast<int>(deviceHistograms.GetElementCount()));
 
         // Scatter keys
         scatterKeys.SetArg(0, offset);

--- a/CLW/CLWParallelPrimitives.h
+++ b/CLW/CLWParallelPrimitives.h
@@ -32,7 +32,7 @@ class CLWParallelPrimitives
 public:
     // Create primitive instances for the context
     CLWParallelPrimitives(CLWContext context, char const* buildopts = nullptr);
-    CLWParallelPrimitives(){}
+    CLWParallelPrimitives() = default;
     ~CLWParallelPrimitives();
 
     ///  TODO: Make these templates at some point

--- a/CLW/CLWPlatform.cpp
+++ b/CLW/CLWPlatform.cpp
@@ -64,14 +64,14 @@ void CLWPlatform::CreateAllPlatforms(std::vector<CLWPlatform>& platforms)
 
     platforms.clear();
     // Only use CL1.2+ platforms
-    for (int i = 0; i < (int)platformIds.size(); ++i)
+    for (auto & platformId : platformIds)
     {
         size_t size = 0;
-        status = clGetPlatformInfo(platformIds[i], CL_PLATFORM_VERSION, 0, nullptr, &size);
+        status = clGetPlatformInfo(platformId, CL_PLATFORM_VERSION, 0, nullptr, &size);
 
         std::vector<char> version(size);
 
-        status = clGetPlatformInfo(platformIds[i], CL_PLATFORM_VERSION, size, &version[0], 0);
+        status = clGetPlatformInfo(platformId, CL_PLATFORM_VERSION, size, &version[0], nullptr);
 
         std::string versionstr(version.begin(), version.end());
 
@@ -81,15 +81,11 @@ void CLWPlatform::CreateAllPlatforms(std::vector<CLWPlatform>& platforms)
             continue;
         }
 
-        validIds.push_back(platformIds[i]);
+        validIds.push_back(platformId);
     }
 
     std::transform(validIds.cbegin(), validIds.cend(), std::back_inserter(platforms),
         std::bind(&CLWPlatform::Create, std::placeholders::_1, type));
-}
-
-CLWPlatform::~CLWPlatform()
-{
 }
 
 void CLWPlatform::GetPlatformInfoParameter(cl_platform_id id, cl_platform_info param, std::string& result)
@@ -145,7 +141,7 @@ std::string CLWPlatform::GetExtensions() const
 // Get number of devices
 unsigned int                CLWPlatform::GetDeviceCount() const
 {
-    if (devices_.size() == 0)
+    if (devices_.empty())
     {
         InitDeviceList(type_);
     }
@@ -156,7 +152,7 @@ unsigned int                CLWPlatform::GetDeviceCount() const
 // Get idx-th device
 CLWDevice CLWPlatform::GetDevice(unsigned int idx) const
 {
-    if (devices_.size() == 0)
+    if (devices_.empty())
     {
         InitDeviceList(type_);
     }

--- a/CLW/CLWPlatform.h
+++ b/CLW/CLWPlatform.h
@@ -46,7 +46,7 @@ public:
     static CLWPlatform Create(cl_platform_id id, cl_device_type type = CL_DEVICE_TYPE_ALL);
     static void CreateAllPlatforms(std::vector<CLWPlatform>& platforms);
     
-    virtual ~CLWPlatform();
+    virtual ~CLWPlatform() = default;
     
     // Platform info
     std::string GetName() const;
@@ -74,9 +74,6 @@ private:
     mutable std::vector<CLWDevice> devices_;
     cl_device_type type_;
 };
-
-
-
 
 
 #endif

--- a/CLW/CLWProgram.cpp
+++ b/CLW/CLWProgram.cpp
@@ -296,10 +296,6 @@ CLWProgram::CLWProgram(cl_program program)
                   });
 }
 
-CLWProgram::~CLWProgram()
-{
-}
-
 unsigned int CLWProgram::GetKernelCount() const
 {
     return static_cast<unsigned int>(kernels_.size());

--- a/CLW/CLWProgram.h
+++ b/CLW/CLWProgram.h
@@ -65,8 +65,8 @@ public:
 
     static CLWProgram CreateFromBinary(std::uint8_t** binaries, std::size_t* binary_sizes, CLWContext context);
 
-    CLWProgram() {}
-    virtual      ~CLWProgram();
+    CLWProgram() = default;
+    virtual ~CLWProgram() = default;
 
     unsigned int GetKernelCount() const;
     CLWKernel    GetKernel(std::string const& funcName) const;

--- a/CLW/ReferenceCounter.h
+++ b/CLW/ReferenceCounter.h
@@ -39,8 +39,8 @@ template <typename T, cl_int(STDCALL *Retain)(T), cl_int(STDCALL *Release)(T)>
 class ReferenceCounter
 {
 public:
-    typedef ReferenceCounter<T, Retain, Release> SelfType;
-    ReferenceCounter() : object_(nullptr) {}
+    using SelfType = ReferenceCounter<T, Retain, Release>;
+    ReferenceCounter() = default;
     explicit ReferenceCounter(T object) : object_(object)
     {
         RetainObject();
@@ -82,22 +82,20 @@ private:
     void RetainObject()  { if (object_) Retain(object_); }
     void ReleaseObject() { if (object_) Release(object_); }
     
-    T object_;
+    T object_ = nullptr;
 };
 
 template <>
 class ReferenceCounter<cl_platform_id, nullptr, nullptr>
 {
 public:
-    typedef ReferenceCounter<cl_platform_id, nullptr, nullptr> SelfType;
-    ReferenceCounter() : object_(nullptr) {}
+    using SelfType = ReferenceCounter<cl_platform_id, nullptr, nullptr>;
+    ReferenceCounter() = default;
     explicit ReferenceCounter(cl_platform_id object) : object_(object)
     {
     }
     
-    ~ReferenceCounter()
-    {
-    }
+    ~ReferenceCounter() = default;
     
     ReferenceCounter(SelfType const& rhs)
     {
@@ -121,7 +119,7 @@ public:
     
 private:
     
-    cl_platform_id object_;
+    cl_platform_id object_ = nullptr;
 };
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(RR_NO_TESTS "Don't add any unit tests and remove any test functionality f
 option(RR_ENABLE_STATIC "Create static libraries rather than dynamic" OFF)
 option(RR_SHARED_CALC "Link Calc(compute abstraction layer) dynamically" OFF)
 option(RR_ENABLE_RAYMASK "Enable ray masking in intersection kernels" OFF)
+option(RR_ENABLE_BACKFACE_CULL "Enable backface culling in intersection kernels" OFF)
 #option(RR_TUTORIALS "Add tutorials projects" OFF)
 option(RR_SAFE_MATH "use safe math" OFF)
 mark_as_advanced(FORCE RR_USE_VULKAN)

--- a/Calc/inc/buffer.h
+++ b/Calc/inc/buffer.h
@@ -29,8 +29,8 @@ namespace Calc
     class CALC_API Buffer
     {
     public:
-        Buffer() {}
-        virtual ~Buffer(){};
+        Buffer() = default;
+        virtual ~Buffer() = default;
 
         virtual std::size_t GetSize() const = 0;
 

--- a/Calc/inc/device.h
+++ b/Calc/inc/device.h
@@ -47,9 +47,9 @@ namespace Calc
         std::uint32_t min_alignment;
         std::uint32_t max_num_queues;
 
-        unsigned __int64 global_mem_size;
-        unsigned __int64 local_mem_size;
-        unsigned __int64 max_alloc_size;
+        unsigned long long global_mem_size;
+        unsigned long long local_mem_size;
+        unsigned long long max_alloc_size;
         std::size_t max_local_size;
 
         bool has_fp16;

--- a/Calc/inc/device.h
+++ b/Calc/inc/device.h
@@ -47,9 +47,9 @@ namespace Calc
         std::uint32_t min_alignment;
         std::uint32_t max_num_queues;
 
-        std::size_t global_mem_size;
-        std::size_t local_mem_size;
-        std::size_t max_alloc_size;
+        unsigned __int64 global_mem_size;
+        unsigned __int64 local_mem_size;
+        unsigned __int64 max_alloc_size;
         std::size_t max_local_size;
 
         bool has_fp16;

--- a/Calc/inc/event.h
+++ b/Calc/inc/event.h
@@ -29,8 +29,8 @@ namespace Calc
     class CALC_API Event
     {
     public:
-        Event() {}
-        virtual ~Event() = 0;
+        Event() = default;
+        virtual ~Event() = default;
 
         virtual void Wait() = 0;
         virtual bool IsComplete() const = 0;
@@ -39,5 +39,4 @@ namespace Calc
         Event& operator = (Event const&) = delete;
     };
 
-    inline Event::~Event() {}
 }

--- a/Calc/inc/except.h
+++ b/Calc/inc/except.h
@@ -29,12 +29,9 @@ namespace Calc
     class CALC_API Exception
     {
     public:
-        Exception() {}
-        virtual ~Exception() = 0;
+        Exception() = default;
+        virtual ~Exception() = default;
         virtual char const* what() const = 0;
     };
 
-    inline Exception::~Exception()
-    {
-    }
 }

--- a/Calc/inc/executable.h
+++ b/Calc/inc/executable.h
@@ -38,8 +38,8 @@ namespace Calc
     class CALC_API Function
     {
     public:
-        Function() {}
-        virtual ~Function() = 0;
+        Function() = default;
+        virtual ~Function() = default;
 
         // Argument setters
         virtual void SetArg(std::uint32_t idx, std::size_t arg_size, void* arg) = 0;
@@ -54,8 +54,8 @@ namespace Calc
     class CALC_API Executable
     {
     public:
-        Executable() {}
-        virtual ~Executable() = 0;
+        Executable() = default;
+        virtual ~Executable() = default;
 
         // Function management
         virtual Function* CreateFunction(char const* name) = 0;
@@ -65,11 +65,4 @@ namespace Calc
         Executable& operator = (Executable const&) = delete;
     };
 
-    inline Executable::~Executable()
-    {
-    }
-
-    inline Function::~Function()
-    {
-    }
 }

--- a/Calc/src/calc_clw.cpp
+++ b/Calc/src/calc_clw.cpp
@@ -53,10 +53,6 @@ namespace Calc
         }
     }
 
-    CalcClw::~CalcClw()
-    {
-    }
-
     // Enumerate devices 
     std::uint32_t CalcClw::GetDeviceCount() const
     {

--- a/Calc/src/calc_clw.h
+++ b/Calc/src/calc_clw.h
@@ -33,7 +33,7 @@ namespace Calc
     {
     public:
         CalcClw();
-        ~CalcClw();
+        ~CalcClw() = default;
 
         // Enumerate devices 
         std::uint32_t GetDeviceCount() const override;

--- a/Calc/src/device_clw.cpp
+++ b/Calc/src/device_clw.cpp
@@ -36,7 +36,7 @@ namespace Calc
     {
     public:
         BufferClw(CLWBuffer<char> buffer) : m_buffer(buffer) {}
-        ~BufferClw() override {};
+        ~BufferClw() override = default;
 
         std::size_t GetSize() const override { return m_buffer.GetElementCount(); }
 
@@ -51,9 +51,9 @@ namespace Calc
     class EventClw : public Event
     {
     public:
-        EventClw() {}
+        EventClw() = default;
         EventClw(CLWEvent event);
-        ~EventClw();
+        ~EventClw() = default;
 
         void Wait() override;
         bool IsComplete() const override;
@@ -66,10 +66,6 @@ namespace Calc
 
     EventClw::EventClw(CLWEvent event)
         : m_event(event)
-    {
-    }
-
-    EventClw::~EventClw()
     {
     }
 
@@ -106,7 +102,7 @@ namespace Calc
     {
     public:
         FunctionClw(CLWKernel kernel);
-        ~FunctionClw();
+        ~FunctionClw() = default;
 
         // Argument setters
         void SetArg(std::uint32_t idx, std::size_t arg_size, void* arg) override;
@@ -123,10 +119,6 @@ namespace Calc
 
     FunctionClw::FunctionClw(CLWKernel kernel)
         : m_kernel(kernel)
-    {
-    }
-
-    FunctionClw::~FunctionClw()
     {
     }
 
@@ -178,7 +170,7 @@ namespace Calc
     {
     public:
         ExecutableClw(CLWProgram program);
-        ~ExecutableClw();
+        ~ExecutableClw() = default;
 
         // Function management
         Function* CreateFunction(char const* name) override;
@@ -191,11 +183,6 @@ namespace Calc
     ExecutableClw::ExecutableClw(CLWProgram program)
         : m_program(program)
     {
-    }
-
-    ExecutableClw::~ExecutableClw()
-    {
-
     }
 
     Function* ExecutableClw::CreateFunction(char const* name)
@@ -520,7 +507,7 @@ namespace Calc
 
     void DeviceClw::WaitForMultipleEvents(Event** e, std::size_t num_events)
     {
-        for (auto i = 0; i < num_events; ++i)
+        for (auto i = 0U; i < num_events; ++i)
         {
             e[i]->Wait();
         }

--- a/Calc/src/device_clw.h
+++ b/Calc/src/device_clw.h
@@ -34,7 +34,7 @@ namespace Calc
     class DeviceClw : public DeviceCl
     {
     public:
-        DeviceClw(cl_context context, cl_device_id device, cl_command_queue queue);
+        //DeviceClw(cl_context context, cl_device_id device, cl_command_queue queue);
         DeviceClw(CLWDevice device);
         DeviceClw(CLWDevice device, CLWContext context);
         ~DeviceClw();

--- a/Calc/src/except_clw.h
+++ b/Calc/src/except_clw.h
@@ -31,7 +31,7 @@ namespace Calc
     {
     public:
         ExceptionClw(std::string what) : m_what(what) {}
-        ~ExceptionClw() {}
+        ~ExceptionClw() = default;
 
         char const* what() const override { return m_what.c_str(); }
 

--- a/Doc/RadeonRays.md
+++ b/Doc/RadeonRays.md
@@ -354,12 +354,7 @@ virtual Id Shape::GetId() const = 0;
 ```
 Work with shape id. This id will be used in results of QueryIntersection().  
 * *id* - new shape id.
-```
-virtual void Shape::SetMask(int mask) = 0;
-virtual int Shape::GetMask() const = 0;
-```
-Geometry mask to mask out intersections.  
-* *mask* - mask of shape.
+
 #### Memory management
 ```
 Buffer* IntersectionApi::CreateBuffer(size_t size, void* initdata) const override;

--- a/RadeonRays/CMakeLists.txt
+++ b/RadeonRays/CMakeLists.txt
@@ -195,6 +195,10 @@ if (RR_ENABLE_RAYMASK)
     target_compile_definitions(RadeonRays PRIVATE RR_RAY_MASK)
 endif (RR_ENABLE_RAYMASK)
 
+if (RR_ENABLE_BACKFACE_CULL)
+    target_compile_definitions(RadeonRays PRIVATE RR_BACKFACE_CULL)
+endif (RR_ENABLE_BACKFACE_CULL)
+
 if (RR_USE_OPENCL)
     target_link_libraries(RadeonRays PUBLIC OpenCL::OpenCL)
     target_compile_definitions(RadeonRays PUBLIC USE_OPENCL=1)

--- a/RadeonRays/include/math/float3.h
+++ b/RadeonRays/include/math/float3.h
@@ -54,7 +54,7 @@ namespace RadeonRays
         float x, y, z, w;
     };
 
-    typedef float3 float4;
+    using float4 = float3;
 
 
     inline float3 operator+(float3 const& v1, float3 const& v2)

--- a/RadeonRays/include/math/mathutils.h
+++ b/RadeonRays/include/math/mathutils.h
@@ -40,7 +40,7 @@ THE SOFTWARE.
 namespace RadeonRays
 {
     /// Initialize RNG
-    inline void rand_init() { std::srand((unsigned)std::time(0)); }
+    inline void rand_init() { std::srand((unsigned)std::time(nullptr)); }
 
     /// Generate random float value within [0,1] range
     inline float rand_float() { return (float)std::rand()/RAND_MAX; }
@@ -177,7 +177,7 @@ namespace RadeonRays
     /// This perspective projection matrix effectively maps view frustum to [-1,1]x[-1,1]x[-1,1] clip space, i.e. OpenGL depth
     matrix perspective_proj_rh_gl(float l, float r, float b, float t, float n, float f);
 
-    matrix perspective_proj_fovy(float fovy, float aspect, float n, float f);
+    //matrix perspective_proj_fovy(float fovy, float aspect, float n, float f);
     matrix perspective_proj_fovy_lh_dx(float fovy, float aspect, float n, float f);
     matrix perspective_proj_fovy_lh_gl(float fovy, float aspect, float n, float f);
 

--- a/RadeonRays/include/math/ray.h
+++ b/RadeonRays/include/math/ray.h
@@ -40,7 +40,7 @@ namespace RadeonRays
         {
             SetMaxT(maxt);
             SetTime(time);
-            SetMask(0xFFFFFFFF);
+            SetMask(-1);
             SetActive(true);
         }
 

--- a/RadeonRays/include/math/ray.h
+++ b/RadeonRays/include/math/ray.h
@@ -42,6 +42,7 @@ namespace RadeonRays
             SetTime(time);
             SetMask(-1);
             SetActive(true);
+            SetDoBackfaceCulling(false);
         }
 
         float3 operator ()(float t) const
@@ -89,9 +90,20 @@ namespace RadeonRays
             return extra.y > 0;
         }
 
+        void SetDoBackfaceCulling(bool _bDoBackfaceCulling)
+        {
+            doBackfaceCulling = _bDoBackfaceCulling ? 1 : 0;
+        }
+
+        bool GetDoBackfaceCulling() const
+        {
+            return doBackfaceCulling > 0;
+        }
+
         float4 o;
         float4 d;
         int2 extra;
-        int2 padding;
+        int doBackfaceCulling;
+        int padding;
     };
 }

--- a/RadeonRays/include/radeon_rays.h
+++ b/RadeonRays/include/radeon_rays.h
@@ -107,10 +107,6 @@ namespace RadeonRays
         // ID of a shape
         virtual void SetId(Id id) = 0;
         virtual Id GetId() const = 0;
-
-        // Geometry mask to mask out intersections
-        virtual void SetMask(int mask) = 0;
-        virtual int  GetMask() const = 0;
     };
 
     // Buffer represents a chunk of memory hosted inside the API

--- a/RadeonRays/include/radeon_rays.h
+++ b/RadeonRays/include/radeon_rays.h
@@ -82,7 +82,7 @@ namespace RadeonRays
     };
 
     // Forward declaration of entities
-    typedef int Id;
+    using Id = int;
     const Id kNullId = -1;
 
     // Shape interface to repesent intersectable entities
@@ -91,7 +91,7 @@ namespace RadeonRays
     class RRAPI Shape
     {
     public:
-        virtual ~Shape() = 0;
+        virtual ~Shape() = default;
 
         // World space transform
         virtual void SetTransform(matrix const& m, matrix const& minv) = 0;
@@ -114,14 +114,14 @@ namespace RadeonRays
     class RRAPI Buffer
     {
     public:
-        virtual ~Buffer() = 0;
+        virtual ~Buffer() = default;
     };
 
     // Synchronization object returned by some API routines.
     class RRAPI Event
     {
     public:
-        virtual ~Event() = 0;
+        virtual ~Event() = default;
         // Indicates whether the related action has been completed
         virtual bool Complete() const = 0;
         // Blocks execution until the event is completed
@@ -132,7 +132,7 @@ namespace RadeonRays
     class RRAPI Exception
     {
     public:
-        virtual ~Exception() = 0;
+        virtual ~Exception() = default;
         virtual char const* what() const = 0;
     };
 
@@ -297,15 +297,12 @@ namespace RadeonRays
         virtual void SetOption(char const* name, float value) = 0;
 
     protected:
-        IntersectionApi();
-        IntersectionApi(IntersectionApi const&);
-        IntersectionApi& operator = (IntersectionApi const&);
+        IntersectionApi() = default;
+        IntersectionApi(IntersectionApi const&) = delete;
+        IntersectionApi& operator = (IntersectionApi const&) = delete;
 
-        virtual ~IntersectionApi() = 0;
+        virtual ~IntersectionApi() = default;
     };
-
-    inline IntersectionApi::IntersectionApi(){}
-    inline IntersectionApi::~IntersectionApi(){}
 
     inline Intersection::Intersection()
         : shapeid(kNullId)
@@ -313,10 +310,6 @@ namespace RadeonRays
     {
     }
 
-    inline Buffer::~Buffer(){}
-    inline Shape::~Shape(){}
-    inline Event::~Event(){}
-    inline Exception::~Exception(){}
 }
 
 

--- a/RadeonRays/src/accelerator/bvh.cpp
+++ b/RadeonRays/src/accelerator/bvh.cpp
@@ -83,7 +83,7 @@ namespace RadeonRays
             node->startidx = static_cast<int>(m_packed_indices.size());
             node->numprims = req.numprims;
 
-            for (auto i = 0U; i < req.numprims; ++i)
+            for (auto i = 0; i < req.numprims; ++i)
             {
                 m_packed_indices.push_back(primindices[req.startidx + i]);
             }
@@ -112,7 +112,7 @@ namespace RadeonRays
                         node->startidx = static_cast<int>(m_packed_indices.size());
                         node->numprims = req.numprims;
 
-                        for (auto i = 0U; i < req.numprims; ++i)
+                        for (auto i = 0; i < req.numprims; ++i)
                         {
                             m_packed_indices.push_back(primindices[req.startidx + i]);
                         }
@@ -138,7 +138,7 @@ namespace RadeonRays
 
                 if (near2far)
                 {
-                    while (1)
+                    while (true)
                     {
                         while ((first != last) &&
                             centroids[primindices[first]][axis] < border)
@@ -171,7 +171,7 @@ namespace RadeonRays
                 }
                 else
                 {
-                    while (1)
+                    while (true)
                     {
                         while ((first != last) &&
                             centroids[primindices[first]][axis] >= border)
@@ -295,7 +295,7 @@ namespace RadeonRays
             if (centroid_rng == 0.f) continue;
 
             // Initialize bins
-            for (unsigned i = 0; i < m_num_bins; ++i)
+            for (int i = 0; i < m_num_bins; ++i)
             {
                 bins[axis][i].count = 0;
                 bins[axis][i].bounds = bbox();
@@ -305,7 +305,7 @@ namespace RadeonRays
             for (int i = req.startidx; i < req.startidx + req.numprims; ++i)
             {
                 int idx = primindices[i];
-                int binidx = (int)std::min<float>(m_num_bins * ((centroids[idx][axis] - rootminc) * invcentroid_rng), m_num_bins - 1);
+                int binidx = (int)std::min<float>(static_cast<float>(m_num_bins) * ((centroids[idx][axis] - rootminc) * invcentroid_rng), static_cast<float>(m_num_bins - 1));
 
                 ++bins[axis][binidx].count;
                 bins[axis][binidx].bounds.grow(bounds[idx]);
@@ -368,7 +368,7 @@ namespace RadeonRays
 
         // Calc bbox
         bbox centroid_bounds;
-        for (size_t i = 0; i < numbounds; ++i)
+        for (size_t i = 0; i < static_cast<size_t>(numbounds); ++i)
         {
             float3 c = bounds[i].center();
             centroid_bounds.grow(c);

--- a/RadeonRays/src/accelerator/bvh.h
+++ b/RadeonRays/src/accelerator/bvh.h
@@ -48,7 +48,7 @@ namespace RadeonRays
         {
         }
 
-        ~Bvh();
+        ~Bvh() = default;
 
         // World space bounding box
         bbox const& Bounds() const;
@@ -141,8 +141,8 @@ namespace RadeonRays
 
 
     private:
-        Bvh(Bvh const&);
-        Bvh& operator = (Bvh const&);
+        Bvh(Bvh const&) = delete;
+        Bvh& operator = (Bvh const&) = delete;
 
         friend class PlainBvhTranslator;
         friend class FatNodeBvhTranslator;
@@ -174,10 +174,6 @@ namespace RadeonRays
             };
         };
     };
-
-    inline Bvh::~Bvh()
-    {
-    }
 
     inline int const* Bvh::GetIndices() const
     {

--- a/RadeonRays/src/accelerator/bvh2.cpp
+++ b/RadeonRays/src/accelerator/bvh2.cpp
@@ -229,8 +229,8 @@ namespace RadeonRays
         // Number of primitives processed so far
         std::atomic<std::uint32_t> num_refs_processed;
 
-		num_refs_processed.store(0);
-		shutdown.store(false);
+        num_refs_processed.store(0);
+        shutdown.store(false);
 
         requests.push(SplitRequest{
             scene_min,

--- a/RadeonRays/src/accelerator/bvh2.cpp
+++ b/RadeonRays/src/accelerator/bvh2.cpp
@@ -142,10 +142,10 @@ namespace RadeonRays
     }
 
     void Bvh2::BuildImpl(
-        __m128 scene_min,
-        __m128 scene_max,
-        __m128 centroid_scene_min,
-        __m128 centroid_scene_max,
+        __m128 MSVC_X86_ALIGNMENT_FIX scene_min,
+        __m128 MSVC_X86_ALIGNMENT_FIX scene_max,
+        __m128 MSVC_X86_ALIGNMENT_FIX centroid_scene_min,
+        __m128 MSVC_X86_ALIGNMENT_FIX centroid_scene_max,
         const float3 *aabb_min,
         const float3 *aabb_max,
         const float3 *aabb_centroid,

--- a/RadeonRays/src/accelerator/bvh2.h
+++ b/RadeonRays/src/accelerator/bvh2.h
@@ -170,8 +170,8 @@ namespace RadeonRays
         static inline void PropagateBounds(Bvh2 &bvh);
 
     private:
-        Bvh2(const Bvh2 &);
-        Bvh2 &operator = (const Bvh2 &);
+        Bvh2(const Bvh2 &) = delete;
+        Bvh2 &operator = (const Bvh2 &) = delete;
 
         friend class QBvhTranslator;
         friend class IntersectorLDS;
@@ -261,7 +261,7 @@ namespace RadeonRays
             matrix m, minv;
             shape->GetTransform(m, minv);
 
-            for (std::size_t face_index = 0; face_index < mesh->num_faces(); ++face_index, ++current_face)
+            for (int face_index = 0; face_index < mesh->num_faces(); ++face_index, ++current_face)
             {
                 bbox bounds;
                 mesh->GetFaceBounds(face_index, isinstance, bounds);
@@ -289,7 +289,7 @@ namespace RadeonRays
                 _mm_store_ps(&aabb_max[current_face].x, pmax);
                 _mm_store_ps(&aabb_centroid[current_face].x, centroid);
 
-                metadata[current_face] = std::make_pair(shape, face_index);
+                metadata[current_face] = std::make_pair(shape, static_cast<size_t>(face_index));
             }
         }
 

--- a/RadeonRays/src/accelerator/bvh2.h
+++ b/RadeonRays/src/accelerator/bvh2.h
@@ -115,14 +115,10 @@ namespace RadeonRays
 #endif // WIN32
         }
 
-#if defined(_MSC_VER)
-    #if defined(_WIN32)
-        #if defined(_WIN64)
-            #define MSVC_X86_ALIGNMENT_FIX
-        #else
-            #define MSVC_X86_ALIGNMENT_FIX &
-        #endif
-    #endif
+#if _MSC_VER <= 1900 && defined(_WIN32) && !defined(_WIN64)
+    #define MSVC_X86_ALIGNMENT_FIX &
+#else
+    #define MSVC_X86_ALIGNMENT_FIX
 #endif
 
         void BuildImpl(

--- a/RadeonRays/src/accelerator/bvh2.h
+++ b/RadeonRays/src/accelerator/bvh2.h
@@ -115,11 +115,21 @@ namespace RadeonRays
 #endif // WIN32
         }
 
+#if defined(_MSC_VER)
+    #if defined(_WIN32)
+        #if defined(_WIN64)
+            #define MSVC_X86_ALIGNMENT_FIX
+        #else
+            #define MSVC_X86_ALIGNMENT_FIX &
+        #endif
+    #endif
+#endif
+
         void BuildImpl(
-            __m128 scene_min,
-            __m128 scene_max,
-            __m128 centroid_scene_min,
-            __m128 centroid_scene_max,
+            __m128 MSVC_X86_ALIGNMENT_FIX scene_min,
+            __m128 MSVC_X86_ALIGNMENT_FIX scene_max,
+            __m128 MSVC_X86_ALIGNMENT_FIX centroid_scene_min,
+            __m128 MSVC_X86_ALIGNMENT_FIX centroid_scene_max,
             const float3 *aabb_min,
             const float3 *aabb_max,
             const float3 *aabb_centroid,

--- a/RadeonRays/src/accelerator/hlbvh.cpp
+++ b/RadeonRays/src/accelerator/hlbvh.cpp
@@ -57,11 +57,6 @@ namespace RadeonRays
         InitGpuData();
     }
     
-    
-    Hlbvh::~Hlbvh()
-    {
-    }
-    
     void Hlbvh::AllocateBuffers(size_t num_prims)
     {
         // * 3 since only triangles are supported just yet
@@ -167,7 +162,7 @@ namespace RadeonRays
         // Make sure to allocate enough mem on GPU
         // We are trying to reuse space as reallocation takes time
         // but this call might be really frequent
-        if (size > m_gpudata->positions->GetSize())
+        if (static_cast<size_t>(size) > m_gpudata->positions->GetSize())
         {
             AllocateBuffers(size);
         }

--- a/RadeonRays/src/accelerator/hlbvh.h
+++ b/RadeonRays/src/accelerator/hlbvh.h
@@ -40,7 +40,7 @@ namespace RadeonRays
     public:
         Hlbvh(Calc::Device* device);
         
-        virtual ~Hlbvh();
+        virtual ~Hlbvh() = default;
         
         // World space bounding box
         bbox const& Bounds() const;
@@ -65,8 +65,8 @@ namespace RadeonRays
         void InitGpuData();
         void AllocateBuffers(size_t numprims);
         
-        Hlbvh(Hlbvh const&);
-        Hlbvh& operator = (Hlbvh const&);
+        Hlbvh(Hlbvh const&) = delete;
+        Hlbvh& operator = (Hlbvh const&) = delete;
         
         // Context for GPU work submision
         Calc::Device* m_device;

--- a/RadeonRays/src/accelerator/split_bvh.cpp
+++ b/RadeonRays/src/accelerator/split_bvh.cpp
@@ -90,9 +90,10 @@ namespace RadeonRays
             if (split_type == SplitType::kSpatial)
             {
                 // First we need maximum 2x numprims elements allocated
-                if (primrefs.size() < req.startidx + req.numprims * 2)
+                size_t elems = req.startidx + req.numprims * 2;
+                if (primrefs.size() < elems)
                 {
-                    primrefs.resize(req.startidx + req.numprims * 2);
+                    primrefs.resize(elems);
                 }
 
                 // Split prim refs and add extra refs to request
@@ -124,7 +125,7 @@ namespace RadeonRays
                 auto first = req.startidx;
                 auto last = req.startidx + req.numprims;
 
-                while (1)
+                while (true)
                 {
                     while ((first != last) && cmp1(primrefs[first].center[axis], border))
                     {
@@ -249,7 +250,7 @@ namespace RadeonRays
             if (centroid_rng == 0.f) continue;
 
             // Initialize bins
-            for (unsigned i = 0; i < m_num_bins; ++i)
+            for (int i = 0; i < m_num_bins; ++i)
             {
                 bins[axis][i].count = 0;
                 bins[axis][i].bounds = bbox();
@@ -259,7 +260,7 @@ namespace RadeonRays
             for (int i = req.startidx; i < req.startidx + req.numprims; ++i)
             {
                 auto idx = i;
-                auto binidx = (int)std::min<float>(m_num_bins * ((refs[idx].center[axis] - rootminc) * invcentroid_rng), m_num_bins - 1);
+                auto binidx = (int)std::min<float>(static_cast<float>(m_num_bins) * ((refs[idx].center[axis] - rootminc) * invcentroid_rng), static_cast<float>(m_num_bins - 1));
 
                 ++bins[axis][binidx].count;
                 bins[axis][binidx].bounds.grow(refs[idx].bounds);
@@ -480,7 +481,7 @@ namespace RadeonRays
         // Split refs if any of them require to be split
         for (int i = req.startidx; i < req.startidx + req.numprims; ++i)
         {
-            assert(req.startidx + appendprims < refs.size());
+            assert(static_cast<size_t>(req.startidx + appendprims) < refs.size());
 
             PrimRef leftref, rightref;
             if (SplitPrimRef(refs[i], split.dim, split.split, leftref, rightref))

--- a/RadeonRays/src/accelerator/split_bvh.h
+++ b/RadeonRays/src/accelerator/split_bvh.h
@@ -44,7 +44,7 @@ namespace RadeonRays
         {
         }
 
-        ~SplitBvh();
+        ~SplitBvh() = default;
 
     protected:
         struct PrimRef;
@@ -90,8 +90,8 @@ namespace RadeonRays
         // Container for archived chunks
         std::list<std::vector<Node>> m_node_archive;
 
-        SplitBvh(SplitBvh const&);
-        SplitBvh& operator = (SplitBvh const&);
+        SplitBvh(SplitBvh const&) = delete;
+        SplitBvh& operator = (SplitBvh const&) = delete;
 
         friend class PlainBvhTranslator;
         friend class FatNodeBvhTranslator;
@@ -104,8 +104,5 @@ namespace RadeonRays
         float3 center;
         int idx;
     };
-    
-    inline SplitBvh::~SplitBvh()
-    {
-    }
+
 }

--- a/RadeonRays/src/api/radeon_rays_impl.cpp
+++ b/RadeonRays/src/api/radeon_rays_impl.cpp
@@ -57,10 +57,6 @@ namespace RadeonRays
         world_.options_.SetValue(name, value);
     }
 
-    IntersectionApiImpl::~IntersectionApiImpl()
-    {
-    }
-
     Shape* IntersectionApiImpl::CreateMesh(
         // Position data
         float const * vertices, int vnum, int vstride,
@@ -172,7 +168,7 @@ namespace RadeonRays
 
     bool IntersectionApiImpl::IsWorldEmpty()
     {
-        return world_.shapes_.size() == 0;
+        return world_.shapes_.empty();
     }
 
 #ifdef USE_OPENCL

--- a/RadeonRays/src/api/radeon_rays_impl.h
+++ b/RadeonRays/src/api/radeon_rays_impl.h
@@ -136,7 +136,7 @@ namespace RadeonRays
     protected:
         friend class IntersectionApi;
 
-        ~IntersectionApiImpl();
+        ~IntersectionApiImpl() = default;
 
     private:
         // Container for all shapes

--- a/RadeonRays/src/async/thread_pool.h
+++ b/RadeonRays/src/async/thread_pool.h
@@ -40,8 +40,8 @@ namespace RadeonRays
     template <typename T> class thread_safe_queue
     {
     public:
-        thread_safe_queue(){}
-        ~thread_safe_queue(){}
+        thread_safe_queue() = default;
+        ~thread_safe_queue() = default;
 
         // Push element: one of the threads is going to 
         // be woken up to process this if any

--- a/RadeonRays/src/device/calc_intersection_device.cpp
+++ b/RadeonRays/src/device/calc_intersection_device.cpp
@@ -100,7 +100,7 @@ namespace RadeonRays
         {
             if (m_intersector_string != "bvh2l")
             {
-                m_intersector = std::make_unique<IntersectorTwoLevel>(m_device.get());
+                m_intersector.reset(new IntersectorTwoLevel(m_device.get()));
                 m_intersector_string = "bvh2l";
             }
         }
@@ -114,7 +114,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "bvh")
                     {
-                        m_intersector = std::make_unique<IntersectorSkipLinks>(m_device.get());
+                        m_intersector.reset(new IntersectorSkipLinks(m_device.get()));
                         m_intersector_string = "bvh";
                     }
                 }
@@ -126,7 +126,7 @@ namespace RadeonRays
                         m_intersector.reset(new IntersectorShortStack(m_device.get()));
                         m_intersector_string = "fatbvh";
 #else
-                        m_intersector = std::make_unique<IntersectorLDS>(m_device.get());
+                        m_intersector.reset(new IntersectorLDS(m_device.get()));
                         m_intersector_string = "fatbvh";
 #endif
                     }
@@ -135,7 +135,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "hlbvh")
                     {
-                        m_intersector = std::make_unique<IntersectorHlbvh>(m_device.get());
+                        m_intersector.reset(new IntersectorHlbvh(m_device.get()));
                         m_intersector_string = "hlbvh";
                     }
                 }
@@ -143,7 +143,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "hashbvh")
                     {
-                        m_intersector = std::make_unique<IntersectorBitTrail>(m_device.get());
+                        m_intersector.reset(new IntersectorBitTrail(m_device.get()));
                         m_intersector_string = "hashbvh";
                     }
                 }*/

--- a/RadeonRays/src/device/calc_intersection_device.cpp
+++ b/RadeonRays/src/device/calc_intersection_device.cpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include "../intersector/intersector_bittrail.h"
 #include "../world/world.h"
 #include <iostream>
+#include <memory>
 
 namespace RadeonRays
 {
@@ -85,10 +86,10 @@ namespace RadeonRays
             else
             {
                 // Otherwise check if there are instances in the world
-                for (auto iter = world.shapes_.cbegin(); iter != world.shapes_.cend(); ++iter)
+                for (auto shape : world.shapes_)
                 {
                     // Get implementation
-                    auto shapeimpl = static_cast<ShapeImpl const*>(*iter);
+                    auto shapeimpl = static_cast<ShapeImpl const*>(shape);
                     // Check if it is an instance and update flag
                     use2level = use2level | shapeimpl->is_instance();
                 }
@@ -99,7 +100,7 @@ namespace RadeonRays
         {
             if (m_intersector_string != "bvh2l")
             {
-                m_intersector.reset(new IntersectorTwoLevel(m_device.get()));
+                m_intersector = std::make_unique<IntersectorTwoLevel>(m_device.get());
                 m_intersector_string = "bvh2l";
             }
         }
@@ -113,7 +114,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "bvh")
                     {
-                        m_intersector.reset(new IntersectorSkipLinks(m_device.get()));
+                        m_intersector = std::make_unique<IntersectorSkipLinks>(m_device.get());
                         m_intersector_string = "bvh";
                     }
                 }
@@ -125,7 +126,7 @@ namespace RadeonRays
                         m_intersector.reset(new IntersectorShortStack(m_device.get()));
                         m_intersector_string = "fatbvh";
 #else
-                        m_intersector.reset(new IntersectorLDS(m_device.get()));
+                        m_intersector = std::make_unique<IntersectorLDS>(m_device.get());
                         m_intersector_string = "fatbvh";
 #endif
                     }
@@ -134,7 +135,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "hlbvh")
                     {
-                        m_intersector.reset(new IntersectorHlbvh(m_device.get()));
+                        m_intersector = std::make_unique<IntersectorHlbvh>(m_device.get());
                         m_intersector_string = "hlbvh";
                     }
                 }
@@ -142,7 +143,7 @@ namespace RadeonRays
                 {
                     if (m_intersector_string != "hashbvh")
                     {
-                        m_intersector.reset(new IntersectorBitTrail(m_device.get()));
+                        m_intersector = std::make_unique<IntersectorBitTrail>(m_device.get());
                         m_intersector_string = "hashbvh";
                     }
                 }*/

--- a/RadeonRays/src/except/except.h
+++ b/RadeonRays/src/except/except.h
@@ -36,7 +36,7 @@ namespace RadeonRays
         {
         }
 
-        virtual char const* what() const
+        char const* what() const override
         {
             return message_.c_str();
         }

--- a/RadeonRays/src/intersector/intersector.cpp
+++ b/RadeonRays/src/intersector/intersector.cpp
@@ -9,10 +9,6 @@ namespace RadeonRays
                   [device](Calc::Buffer* buffer) { device->DeleteBuffer(buffer); })
     {
     }
-
-    Intersector::~Intersector()
-    {
-    }
     
     void Intersector::SetWorld(World const &world)
     {

--- a/RadeonRays/src/intersector/intersector.h
+++ b/RadeonRays/src/intersector/intersector.h
@@ -55,7 +55,7 @@ namespace RadeonRays
         // which is going to be used by an intersector.
         Intersector(Calc::Device* device);
         // Destructor.
-        virtual ~Intersector();
+        virtual ~Intersector() = default;
 
         /** 
         \brief Check if the intersector is compatible with a given world.

--- a/RadeonRays/src/intersector/intersector_2level.cpp
+++ b/RadeonRays/src/intersector/intersector_2level.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "device.h"
 #include "executable.h"
 
+#include <memory>
 #include <set>
 
 static int const kWorkGroupSize = 64;
@@ -181,9 +182,9 @@ namespace RadeonRays
         int statechange = world.GetStateChange();
 
         // Full rebuild in case number of objects changes
-        if (m_bvhs.size() == 0 || world.has_changed())
+        if (m_bvhs.empty() || world.has_changed())
         {
-            if (m_bvhs.size() != 0)
+            if (!m_bvhs.empty())
             {
                 m_device->DeleteBuffer(m_gpudata->bvh);
                 m_device->DeleteBuffer(m_gpudata->vertices);
@@ -260,7 +261,7 @@ namespace RadeonRays
             // Create actual BVH objects
             for (int i = 0; i < nummeshes + 1; ++i)
             {
-                m_bvhs[i].reset(new Bvh(traversal_cost, num_bins, use_sah));
+                m_bvhs[i] = std::make_unique<Bvh>(traversal_cost, num_bins, use_sah);
                 m_cpudata->bvhptrs[i] = m_bvhs[i].get();
             }
 
@@ -588,7 +589,7 @@ namespace RadeonRays
                 use_sah = true;
             }
 
-            m_bvhs[nummeshes].reset(new Bvh(traversal_cost, num_bins, use_sah));
+            m_bvhs[nummeshes] = std::make_unique<Bvh>(traversal_cost, num_bins, use_sah);
             m_bvhs[nummeshes]->Build(&object_bounds[0], nummeshes + numinstances);
             m_cpudata->bvhptrs[nummeshes] = m_bvhs[nummeshes].get();
 

--- a/RadeonRays/src/intersector/intersector_2level.cpp
+++ b/RadeonRays/src/intersector/intersector_2level.cpp
@@ -42,7 +42,8 @@ namespace RadeonRays
         Id id;
         // Index of root bvh node
         int bvhidx;
-        int mask;
+        // Is the shape disabled?
+        unsigned int shapeDisabled;
         int padding1;
         // Transform
         matrix minv;
@@ -56,8 +57,6 @@ namespace RadeonRays
     {
         // Up to 3 indices
         int idx[3];
-        // Shape maks
-        int shape_mask;
         // Shape ID
         int shape_id;
         // Primitive ID
@@ -455,11 +454,11 @@ namespace RadeonRays
                 // and we need to skip them while doing traversal.
                 if (shapes_disabled.find(shapeimpl) == shapes_disabled.cend())
                 {
-                    m_cpudata->shapedata[i].mask = shapeimpl->GetMask();
+                    m_cpudata->shapedata[i].shapeDisabled = 0;
                 }
                 else
                 {
-                    m_cpudata->shapedata[i].mask = 0x0;
+                    m_cpudata->shapedata[i].shapeDisabled = 1;
                 }
 
                 shapeimpl->GetTransform(m, m_cpudata->shapedata[i].minv);
@@ -618,11 +617,11 @@ namespace RadeonRays
                 // and we need to skip them while doing traversal.
                 if (shapes_disabled.find(shapeimpl) == shapes_disabled.cend())
                 {
-                    m_cpudata->shapedata[i].mask = shapeimpl->GetMask();
+                    m_cpudata->shapedata[i].shapeDisabled = 0;
                 }
                 else
                 {
-                    m_cpudata->shapedata[i].mask = 0x0;
+                    m_cpudata->shapedata[i].shapeDisabled = 1;
                 }
 
                 shapeimpl->GetTransform(m, m_cpudata->shapedata[i].minv);

--- a/RadeonRays/src/intersector/intersector_2level.cpp
+++ b/RadeonRays/src/intersector/intersector_2level.cpp
@@ -127,13 +127,15 @@ namespace RadeonRays
         , m_gpudata(new GpuData(device))
         , m_cpudata(new CpuData)
     {
-        std::string buildopts =
+        std::string buildopts;
 #ifdef RR_RAY_MASK
-            "-D RR_RAY_MASK ";
-#else
-            "";
+        buildopts.append("-D RR_RAY_MASK ");
 #endif
-        
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
+
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");
 #endif

--- a/RadeonRays/src/intersector/intersector_bittrail.cpp
+++ b/RadeonRays/src/intersector/intersector_bittrail.cpp
@@ -340,7 +340,7 @@ namespace RadeonRays
                 // Besides that we need to permute the faces accorningly to BVH reordering, whihc
                 // is contained within bvh.primids_
                 int const* reordering = m_bvh->GetIndices();
-                for (int i = 0; i < numindices; ++i)
+                for (size_t i = 0; i < numindices; ++i)
                 {
                     int indextolook4 = reordering[i];
 

--- a/RadeonRays/src/intersector/intersector_bittrail.cpp
+++ b/RadeonRays/src/intersector/intersector_bittrail.cpp
@@ -372,7 +372,6 @@ namespace RadeonRays
                     facedata[i].idx[2] = myfacedata[faceidx].idx[2] + mystartidx;
 
                     facedata[i].shapeidx = shapes[shapeidx]->GetId();
-                    facedata[i].shape_mask = shapes[shapeidx]->GetMask();
                     facedata[i].id = faceidx;
                 }
 

--- a/RadeonRays/src/intersector/intersector_bittrail.cpp
+++ b/RadeonRays/src/intersector/intersector_bittrail.cpp
@@ -88,13 +88,15 @@ namespace RadeonRays
         , m_gpudata(new GpuData(device))
         , m_bvh(nullptr)
     {
-        std::string buildopts =
+        std::string buildopts;
 #ifdef RR_RAY_MASK
-            "-D RR_RAY_MASK ";
-#else
-            "";
+        buildopts.append("-D RR_RAY_MASK ");
 #endif
-        
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
+
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");
 #endif

--- a/RadeonRays/src/intersector/intersector_hlbvh.cpp
+++ b/RadeonRays/src/intersector/intersector_hlbvh.cpp
@@ -222,8 +222,6 @@ namespace RadeonRays
                 {
                     // Up to 3 indices
                     int idx[3];
-                    // Shape maks
-                    int shape_mask;
                     // Shape ID
                     int shape_id;
                     // Primitive ID
@@ -273,7 +271,6 @@ namespace RadeonRays
 
                     // Optimization: we are putting faceid here
                     facedata[i].shape_id = mesh->GetId();
-                    facedata[i].shape_mask = mesh->GetMask();
                     facedata[i].prim_id = faceidx;
                 }
 

--- a/RadeonRays/src/intersector/intersector_hlbvh.cpp
+++ b/RadeonRays/src/intersector/intersector_hlbvh.cpp
@@ -77,13 +77,15 @@ namespace RadeonRays
         , m_gpudata(new GpuData(device))
         , m_bvh(nullptr)
     {
-        std::string buildopts =
+        std::string buildopts;
 #ifdef RR_RAY_MASK
-            "-D RR_RAY_MASK ";
-#else
-            "";
+        buildopts.append("-D RR_RAY_MASK ");
 #endif
-        
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
+
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");
 #endif

--- a/RadeonRays/src/intersector/intersector_hlbvh.cpp
+++ b/RadeonRays/src/intersector/intersector_hlbvh.cpp
@@ -30,7 +30,9 @@ THE SOFTWARE.
 #include "device.h"
 #include "executable.h"
 #include "../except/except.h"
+
 #include <algorithm>
+#include <memory>
 
 // Preferred work group size for Radeon devices
 static int const kWorkGroupSize = 64;
@@ -146,7 +148,7 @@ namespace RadeonRays
             std::vector<int> mesh_faces_start_idx(numshapes);
 
             //
-            m_bvh.reset(new Hlbvh(m_device));
+            m_bvh = std::make_unique<Hlbvh>(m_device);
 
             // Here we now that only Meshes are present, otherwise 2level strategy would have been used
             for (int i = 0; i < numshapes; ++i)

--- a/RadeonRays/src/intersector/intersector_lds.cpp
+++ b/RadeonRays/src/intersector/intersector_lds.cpp
@@ -100,6 +100,11 @@ namespace RadeonRays
 #ifdef RR_RAY_MASK
         buildopts.append("-D RR_RAY_MASK ");
 #endif
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
+
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");
 #endif

--- a/RadeonRays/src/intersector/intersector_lds.cpp
+++ b/RadeonRays/src/intersector/intersector_lds.cpp
@@ -245,8 +245,8 @@ namespace RadeonRays
 
                 // Copy BVH data
                 std::size_t i = 0;
-                for (auto it = translator.nodes_.begin(); it != translator.nodes_.end(); ++it)
-                    bvhdata[i++] = *it;
+                for (auto & node : translator.nodes_)
+                    bvhdata[i++] = node;
 
                 // Unmap gpu data
                 m_device->UnmapBuffer(m_gpudata->bvh, 0, bvhdata, &e);

--- a/RadeonRays/src/intersector/intersector_short_stack.cpp
+++ b/RadeonRays/src/intersector/intersector_short_stack.cpp
@@ -385,7 +385,6 @@ namespace RadeonRays
                     facedata[i].idx[2] = myfacedata[faceidx].idx[2] + mystartidx;
 
                     facedata[i].shapeidx = shapes[shapeidx]->GetId();
-                    facedata[i].shape_mask = shapes[shapeidx]->GetMask();
                     facedata[i].id = faceidx;
                 }
 

--- a/RadeonRays/src/intersector/intersector_short_stack.cpp
+++ b/RadeonRays/src/intersector/intersector_short_stack.cpp
@@ -83,13 +83,15 @@ namespace RadeonRays
         , m_gpudata(new GpuData(device))
         , m_bvh(nullptr)
     {
-        std::string buildopts =
+        std::string buildopts;
 #ifdef RR_RAY_MASK
-            "-D RR_RAY_MASK ";
-#else
-            "";
+        buildopts.append("-D RR_RAY_MASK ");
 #endif
-        
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
+
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");
 #endif

--- a/RadeonRays/src/intersector/intersector_short_stack.cpp
+++ b/RadeonRays/src/intersector/intersector_short_stack.cpp
@@ -353,7 +353,7 @@ namespace RadeonRays
                 // Besides that we need to permute the faces accorningly to BVH reordering, whihc
                 // is contained within bvh.primids_
                 int const* reordering = m_bvh->GetIndices();
-                for (int i = 0; i < numindices; ++i)
+                for (size_t i = 0; i < numindices; ++i)
                 {
                     int indextolook4 = reordering[i];
 

--- a/RadeonRays/src/intersector/intersector_skip_links.cpp
+++ b/RadeonRays/src/intersector/intersector_skip_links.cpp
@@ -331,8 +331,6 @@ namespace RadeonRays
                 {
                     // Up to 3 indices
                     int idx[3];
-                    // Shape maks
-                    int shape_mask;
                     // Shape ID
                     int shape_id;
                     // Primitive ID
@@ -393,7 +391,6 @@ namespace RadeonRays
 
                     // Optimization: we are putting faceid here
                     facedata[i].shape_id = shapes[shapeidx]->GetId();
-                    facedata[i].shape_mask = shapes[shapeidx]->GetMask();
                     facedata[i].prim_id = faceidx;
                 }
 

--- a/RadeonRays/src/intersector/intersector_skip_links.cpp
+++ b/RadeonRays/src/intersector/intersector_skip_links.cpp
@@ -358,7 +358,7 @@ namespace RadeonRays
                 // Besides that we need to permute the faces accorningly to BVH reordering, whihc
                 // is contained within bvh.primids_
                 int const* reordering = m_bvh->GetIndices();
-                for (int i = 0; i < numindices; ++i)
+                for (size_t i = 0; i < numindices; ++i)
                 {
                     int indextolook4 = reordering[i];
 

--- a/RadeonRays/src/intersector/intersector_skip_links.cpp
+++ b/RadeonRays/src/intersector/intersector_skip_links.cpp
@@ -81,12 +81,14 @@ namespace RadeonRays
         , m_gpudata(new GpuData(device))
         , m_bvh(nullptr)
     {
-        std::string buildopts =
+        std::string buildopts;
 #ifdef RR_RAY_MASK
-            "-D RR_RAY_MASK ";
-#else
-            "";
+        buildopts.append("-D RR_RAY_MASK ");
 #endif
+
+#ifdef RR_BACKFACE_CULL
+        buildopts.append("-D RR_BACKFACE_CULL ");
+#endif // RR_BACKFACE_CULL
 
 #ifdef USE_SAFE_MATH
         buildopts.append("-D USE_SAFE_MATH ");

--- a/RadeonRays/src/kernels/CL/common.cl
+++ b/RadeonRays/src/kernels/CL/common.cl
@@ -55,7 +55,8 @@ typedef struct
     float4 o;
     float4 d;
     int2 extra;
-    int2 padding;
+    int doBackfaceCulling;
+    int padding;
 } ray;
 
 // Intersection definition
@@ -94,6 +95,12 @@ INLINE
 float ray_get_time(ray const* r)
 {
     return r->d.w;
+}
+
+INLINE
+int ray_get_doBackfaceCull(ray const* r)
+{
+    return r->doBackfaceCulling;
 }
 
 /*************************************************************************
@@ -172,6 +179,14 @@ float fast_intersect_triangle(ray r, float3 v1, float3 v2, float3 v3, float t_ma
 {
     float3 const e1 = v2 - v1;
     float3 const e2 = v3 - v1;
+
+#ifdef RR_BACKFACE_CULL
+    if (ray_get_doBackfaceCull(&r) && dot(cross(e1, e2), r.d.xyz) > 0.f)
+    {
+        return t_max;
+    }
+#endif // RR_BACKFACE_CULL
+
     float3 const s1 = cross(r.d.xyz, e2);
 
     float denom = dot(s1, e1);

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_bittrail.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_bittrail.cl
@@ -115,8 +115,6 @@ typedef struct
             int i0, i1, i2;
             // Address of a left child
             int child0;
-            // Shape mask
-            int shape_mask;
             // Shape ID
             int shape_id;
             // Primitive ID
@@ -183,19 +181,26 @@ occluded_main(
                 // Check if it is a leaf
                 if (LEAFNODE(node))
                 {
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[node.i0];
-                    float3 const v2 = vertices[node.i1];
-                    float3 const v3 = vertices[node.i2];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit store the result and bail out
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != node.shape_id)
                     {
-                        hits[global_id] = HIT_MARKER;
-                        return;
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[node.i0];
+                        float3 const v2 = vertices[node.i1];
+                        float3 const v3 = vertices[node.i2];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit store the result and bail out
+                        if (f < t_max)
+                        {
+                            hits[global_id] = HIT_MARKER;
+                            return;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {
@@ -327,19 +332,26 @@ KERNEL void intersect_main(
                 // Check if it is a leaf
                 if (LEAFNODE(node))
                 {
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[node.i0];
-                    float3 const v2 = vertices[node.i1];
-                    float3 const v3 = vertices[node.i2];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit update closest hit distance and index
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != node.shape_id)
                     {
-                        t_max = f;
-                        isect_idx = addr;
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[node.i0];
+                        float3 const v2 = vertices[node.i1];
+                        float3 const v3 = vertices[node.i2];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit update closest hit distance and index
+                        if (f < t_max)
+                        {
+                            t_max = f;
+                            isect_idx = addr;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_bittrail.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_bittrail.cl
@@ -184,7 +184,7 @@ occluded_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != node.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[node.i0];
@@ -200,7 +200,7 @@ occluded_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {
@@ -335,7 +335,7 @@ KERNEL void intersect_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != node.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[node.i0];
@@ -351,7 +351,7 @@ KERNEL void intersect_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
@@ -160,18 +160,25 @@ KERNEL void intersect_main(
                 }
                 else
                 {
-                    float t = fast_intersect_triangle(
-                        my_ray,
-                        node.aabb_left_min_or_v0_and_addr_left.xyz,
-                        node.aabb_left_max_or_v1_and_mesh_id.xyz,
-                        node.aabb_right_min_or_v2_and_addr_right.xyz,
-                        closest_t);
-
-                    if (t < closest_t)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-                        closest_t = t;
-                        closest_addr = addr;
+#endif
+                        float t = fast_intersect_triangle(
+                            my_ray,
+                            node.aabb_left_min_or_v0_and_addr_left.xyz,
+                            node.aabb_left_max_or_v1_and_mesh_id.xyz,
+                            node.aabb_right_min_or_v2_and_addr_right.xyz,
+                            closest_t);
+
+                        if (t < closest_t)
+                        {
+                            closest_t = t;
+                            closest_addr = addr;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
 
                 addr = lds_stack[--lds_sptr];
@@ -313,18 +320,25 @@ KERNEL void occluded_main(
                 }
                 else
                 {
-                    float t = fast_intersect_triangle(
-                        my_ray,
-                        node.aabb_left_min_or_v0_and_addr_left.xyz,
-                        node.aabb_left_max_or_v1_and_mesh_id.xyz,
-                        node.aabb_right_min_or_v2_and_addr_right.xyz,
-                        closest_t);
-
-                    if (t < closest_t)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-                        hits[index] = HIT_MARKER;
-                        return;
+#endif
+                        float t = fast_intersect_triangle(
+                            my_ray,
+                            node.aabb_left_min_or_v0_and_addr_left.xyz,
+                            node.aabb_left_max_or_v1_and_mesh_id.xyz,
+                            node.aabb_right_min_or_v2_and_addr_right.xyz,
+                            closest_t);
+
+                        if (t < closest_t)
+                        {
+                            hits[index] = HIT_MARKER;
+                            return;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
 
                 addr = lds_stack[--lds_sptr];

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_lds.cl
@@ -163,7 +163,7 @@ KERNEL void intersect_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-#endif
+#endif // RR_RAY_MASK
                         float t = fast_intersect_triangle(
                             my_ray,
                             node.aabb_left_min_or_v0_and_addr_left.xyz,
@@ -178,7 +178,7 @@ KERNEL void intersect_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
 
                 addr = lds_stack[--lds_sptr];
@@ -323,7 +323,7 @@ KERNEL void occluded_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-#endif
+#endif // RR_RAY_MASK
                         float t = fast_intersect_triangle(
                             my_ray,
                             node.aabb_left_min_or_v0_and_addr_left.xyz,
@@ -338,7 +338,7 @@ KERNEL void occluded_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
 
                 addr = lds_stack[--lds_sptr];

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_lds_fp16.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_lds_fp16.cl
@@ -251,7 +251,7 @@ KERNEL void intersect_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-#endif
+#endif // RR_RAY_MASK
                         float t = fast_intersect_triangle(
                             my_ray,
                             as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
@@ -266,7 +266,7 @@ KERNEL void intersect_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
 
                 addr = lds_stack[--lds_sptr];
@@ -437,7 +437,7 @@ KERNEL void occluded_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-#endif
+#endif // RR_RAY_MASK
                         float t = fast_intersect_triangle(
                             my_ray,
                             as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
@@ -452,7 +452,7 @@ KERNEL void occluded_main(
                         }
 #ifdef RR_RAY_MASK
                 }
-#endif
+#endif // RR_RAY_MASK
                 }
 
                 addr = lds_stack[--lds_sptr];

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_lds_fp16.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_lds_fp16.cl
@@ -248,18 +248,25 @@ KERNEL void intersect_main(
                 }
                 else
                 {
-                    float t = fast_intersect_triangle(
-                        my_ray,
-                        as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
-                        as_float3(node.aabb01_max_or_v1_and_addr1_or_mesh_id.xyz),
-                        as_float3(node.aabb23_min_or_v2_and_addr2_or_prim_id.xyz),
-                        closest_t);
-
-                    if (t < closest_t)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-                        closest_t = t;
-                        closest_addr = addr;
+#endif
+                        float t = fast_intersect_triangle(
+                            my_ray,
+                            as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
+                            as_float3(node.aabb01_max_or_v1_and_addr1_or_mesh_id.xyz),
+                            as_float3(node.aabb23_min_or_v2_and_addr2_or_prim_id.xyz),
+                            closest_t);
+
+                        if (t < closest_t)
+                        {
+                            closest_t = t;
+                            closest_addr = addr;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
 
                 addr = lds_stack[--lds_sptr];
@@ -427,18 +434,25 @@ KERNEL void occluded_main(
                 }
                 else
                 {
-                    float t = fast_intersect_triangle(
-                        my_ray,
-                        as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
-                        as_float3(node.aabb01_max_or_v1_and_addr1_or_mesh_id.xyz),
-                        as_float3(node.aabb23_min_or_v2_and_addr2_or_prim_id.xyz),
-                        closest_t);
-
-                    if (t < closest_t)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&my_ray) != convert_int(GetMeshId(node)))
                     {
-                        hits[index] = HIT_MARKER;
-                        return;
-                    }
+#endif
+                        float t = fast_intersect_triangle(
+                            my_ray,
+                            as_float3(node.aabb01_min_or_v0_and_addr0.xyz),
+                            as_float3(node.aabb01_max_or_v1_and_addr1_or_mesh_id.xyz),
+                            as_float3(node.aabb23_min_or_v2_and_addr2_or_prim_id.xyz),
+                            closest_t);
+
+                        if (t < closest_t)
+                        {
+                            hits[index] = HIT_MARKER;
+                            return;
+                        }
+#ifdef RR_RAY_MASK
+                }
+#endif
                 }
 
                 addr = lds_stack[--lds_sptr];

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_short_stack.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_short_stack.cl
@@ -111,8 +111,6 @@ typedef struct
             int i0, i1, i2;
             // Address of a left child
             int child0;
-            // Shape mask
-            int shape_mask;
             // Shape ID
             int shape_id;
             // Primitive ID
@@ -187,19 +185,26 @@ occluded_main(
                 // Check if it is a leaf
                 if (LEAFNODE(node))
                 {
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[node.i0];
-                    float3 const v2 = vertices[node.i1];
-                    float3 const v3 = vertices[node.i2];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit update closest hit distance and index
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != node.shape_id)
                     {
-                        hits[global_id] = HIT_MARKER;
-                        return;
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[node.i0];
+                        float3 const v2 = vertices[node.i1];
+                        float3 const v3 = vertices[node.i2];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit update closest hit distance and index
+                        if (f < t_max)
+                        {
+                            hits[global_id] = HIT_MARKER;
+                            return;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {
@@ -339,19 +344,26 @@ KERNEL void intersect_main(
                 // Check if it is a leaf
                 if (LEAFNODE(node))
                 {
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[node.i0];
-                    float3 const v2 = vertices[node.i1];
-                    float3 const v3 = vertices[node.i2];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit update closest hit distance and index
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != node.shape_id)
                     {
-                        t_max = f;
-                        isect_idx = addr;
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[node.i0];
+                        float3 const v2 = vertices[node.i1];
+                        float3 const v3 = vertices[node.i2];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit update closest hit distance and index
+                        if (f < t_max)
+                        {
+                            t_max = f;
+                            isect_idx = addr;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_short_stack.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_short_stack.cl
@@ -188,7 +188,7 @@ occluded_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != node.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[node.i0];
@@ -204,7 +204,7 @@ occluded_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {
@@ -347,7 +347,7 @@ KERNEL void intersect_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != node.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[node.i0];
@@ -363,7 +363,7 @@ KERNEL void intersect_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_skiplinks.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_skiplinks.cl
@@ -146,7 +146,7 @@ void intersect_main(
 #ifdef RR_RAY_MASK
                         if (ray_get_mask(&r) != face.shape_id)
                         {
-#endif
+#endif // RR_RAY_MASK
                             float3 const v1 = vertices[face.idx[0]];
                             float3 const v2 = vertices[face.idx[1]];
                             float3 const v3 = vertices[face.idx[2]];
@@ -161,7 +161,7 @@ void intersect_main(
                             }
 #ifdef RR_RAY_MASK
                         }
-#endif
+#endif // RR_RAY_MASK
                     }
                     else
                     {
@@ -255,7 +255,7 @@ void occluded_main(
 #ifdef RR_RAY_MASK
                         if (ray_get_mask(&r) != face.shape_id)
                         {
-#endif
+#endif // RR_RAY_MASK
                             float3 const v1 = vertices[face.idx[0]];
                             float3 const v2 = vertices[face.idx[1]];
                             float3 const v3 = vertices[face.idx[2]];
@@ -270,7 +270,7 @@ void occluded_main(
                             }
 #ifdef RR_RAY_MASK
                         }
-#endif
+#endif // RR_RAY_MASK
                     }
                     else
                     {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2_skiplinks.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2_skiplinks.cl
@@ -86,8 +86,6 @@ typedef struct
 {
     // Vertex indices
     int idx[3];
-    // Shape maks
-    int shape_mask;
     // Shape ID
     int shape_id;
     // Primitive ID
@@ -145,18 +143,25 @@ void intersect_main(
                     {
                         int const face_idx = STARTIDX(node);
                         Face const face = faces[face_idx];
-                        float3 const v1 = vertices[face.idx[0]];
-                        float3 const v2 = vertices[face.idx[1]];
-                        float3 const v3 = vertices[face.idx[2]];
-
-                        // Intersect triangle
-                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                        // If hit update closest hit distance and index
-                        if (f < t_max)
+#ifdef RR_RAY_MASK
+                        if (ray_get_mask(&r) != face.shape_id)
                         {
-                            t_max = f;
-                            isect_idx = face_idx;
+#endif
+                            float3 const v1 = vertices[face.idx[0]];
+                            float3 const v2 = vertices[face.idx[1]];
+                            float3 const v3 = vertices[face.idx[2]];
+
+                            // Intersect triangle
+                            float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                            // If hit update closest hit distance and index
+                            if (f < t_max)
+                            {
+                                t_max = f;
+                                isect_idx = face_idx;
+                            }
+#ifdef RR_RAY_MASK
                         }
+#endif
                     }
                     else
                     {
@@ -247,18 +252,25 @@ void occluded_main(
                     {
                         int const face_idx = STARTIDX(node);
                         Face const face = faces[face_idx];
-                        float3 const v1 = vertices[face.idx[0]];
-                        float3 const v2 = vertices[face.idx[1]];
-                        float3 const v3 = vertices[face.idx[2]];
-
-                        // Intersect triangle
-                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                        // If hit store the result and bail out
-                        if (f < t_max)
+#ifdef RR_RAY_MASK
+                        if (ray_get_mask(&r) != face.shape_id)
                         {
-                            hits[global_id] = HIT_MARKER;
-                            return;
+#endif
+                            float3 const v1 = vertices[face.idx[0]];
+                            float3 const v2 = vertices[face.idx[1]];
+                            float3 const v3 = vertices[face.idx[2]];
+
+                            // Intersect triangle
+                            float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                            // If hit store the result and bail out
+                            if (f < t_max)
+                            {
+                                hits[global_id] = HIT_MARKER;
+                                return;
+                            }
+#ifdef RR_RAY_MASK
                         }
+#endif
                     }
                     else
                     {

--- a/RadeonRays/src/kernels/CL/intersect_bvh2level_skiplinks.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2level_skiplinks.cl
@@ -78,8 +78,8 @@ typedef struct
     int id;
     // Shape BVH index (bottom level)
     int bvh_idx;
-    // Shape mask
-    int mask;
+    // Is the shape disabled?
+    unsigned int shapeDisabled;
     int padding1;
     // Transform
     float4 m0;
@@ -95,8 +95,6 @@ typedef struct
 {
     // Vertex indices
     int idx[3];
-    // Shape maks
-    int shape_mask;
     // Shape ID
     int shape_id;
     // Primitive ID
@@ -230,14 +228,19 @@ KERNEL void intersect_main(
                             // Get shape descrition struct index
                             int shape_idx = SHAPEIDX(node);
                             // Get shape mask
-                            int shape_mask = shapes[shape_idx].mask;
+                            unsigned int const shapeDisabled = shapes[shape_idx].shapeDisabled;
+                            int const shapeId = shapes[shape_idx].id;
                             // Drill into 2nd level BVH only if the geometry is not masked vs current ray
                             // otherwise skip the subtree
-                            if (ray_get_mask(&r) & shape_mask)
+                            if (!shapeDisabled
+#ifdef RR_RAY_MASK
+                                && ray_get_mask(&r) != shapeId
+#endif
+                                )
                             {
                                 // Fetch bottom level BVH index
                                 addr = shapes[shape_idx].bvh_idx;
-                                shape_id = shapes[shape_idx].id;
+                                shape_id = shapeId;
 
                                 // Fetch BVH transform
                                 float4 wmi0 = shapes[shape_idx].m0;
@@ -389,10 +392,17 @@ KERNEL void occluded_main(
                             // Get shape descrition struct index
                             int shape_idx = SHAPEIDX(node);
                             // Get shape mask
-                            int shape_mask = shapes[shape_idx].mask;
+                            const unsigned int shapeDisabled = shapes[shape_idx].shapeDisabled;
+#ifdef RR_RAY_MASK
+                            const int shapeId = shapes[shape_idx].id;
+#endif
                             // Drill into 2nd level BVH only if the geometry is not masked vs current ray
                             // otherwise skip the subtree
-                            if (ray_get_mask(&r) & shape_mask)
+                            if (!shapeDisabled 
+#ifdef RR_RAY_MASK
+                                && ray_get_mask(&r) != shapeId
+#endif
+                                )
                             {
                                 // Fetch bottom level BVH index
                                 addr = shapes[shape_idx].bvh_idx;
@@ -405,7 +415,7 @@ KERNEL void occluded_main(
 
                                 r = transform_ray(r, wmi0, wmi1, wmi2, wmi3);
                                 // Recalc invdir
-                                invdir = safe_invdir(r);;
+                                invdir = safe_invdir(r);
                                 // And continue traversal of the bottom level BVH
                                 continue;
                             }

--- a/RadeonRays/src/kernels/CL/intersect_bvh2level_skiplinks.cl
+++ b/RadeonRays/src/kernels/CL/intersect_bvh2level_skiplinks.cl
@@ -235,7 +235,7 @@ KERNEL void intersect_main(
                             if (!shapeDisabled
 #ifdef RR_RAY_MASK
                                 && ray_get_mask(&r) != shapeId
-#endif
+#endif // RR_RAY_MASK
                                 )
                             {
                                 // Fetch bottom level BVH index
@@ -395,13 +395,13 @@ KERNEL void occluded_main(
                             const unsigned int shapeDisabled = shapes[shape_idx].shapeDisabled;
 #ifdef RR_RAY_MASK
                             const int shapeId = shapes[shape_idx].id;
-#endif
+#endif // RR_RAY_MASK
                             // Drill into 2nd level BVH only if the geometry is not masked vs current ray
                             // otherwise skip the subtree
                             if (!shapeDisabled 
 #ifdef RR_RAY_MASK
                                 && ray_get_mask(&r) != shapeId
-#endif
+#endif // RR_RAY_MASK
                                 )
                             {
                                 // Fetch bottom level BVH index

--- a/RadeonRays/src/kernels/CL/intersect_hlbvh_stack.cl
+++ b/RadeonRays/src/kernels/CL/intersect_hlbvh_stack.cl
@@ -142,7 +142,7 @@ occluded_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != face.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[face.idx[0]];
@@ -158,7 +158,7 @@ occluded_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {
@@ -305,7 +305,7 @@ KERNEL void intersect_main(
 #ifdef RR_RAY_MASK
                     if (ray_get_mask(&r) != face.shape_id)
                     {
-#endif
+#endif // RR_RAY_MASK
                         // Leafs directly store vertex indices
                         // so we load vertices directly
                         float3 const v1 = vertices[face.idx[0]];
@@ -321,7 +321,7 @@ KERNEL void intersect_main(
                         }
 #ifdef RR_RAY_MASK
                     }
-#endif
+#endif // RR_RAY_MASK
                 }
                 else
                 {

--- a/RadeonRays/src/kernels/CL/intersect_hlbvh_stack.cl
+++ b/RadeonRays/src/kernels/CL/intersect_hlbvh_stack.cl
@@ -68,8 +68,6 @@ typedef struct
 {
     // Vertex indices
     int idx[3];
-    // Shape maks
-    int shape_mask;
     // Shape ID
     int shape_id;
     // Primitive ID
@@ -141,19 +139,26 @@ occluded_main(
                 if (LEAFNODE(node))
                 {
                     Face face = faces[STARTIDX(node)];
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[face.idx[0]];
-                    float3 const v2 = vertices[face.idx[1]];
-                    float3 const v3 = vertices[face.idx[2]];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit update closest hit distance and index
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != face.shape_id)
                     {
-                        hits[global_id] = HIT_MARKER;
-                        return;
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[face.idx[0]];
+                        float3 const v2 = vertices[face.idx[1]];
+                        float3 const v3 = vertices[face.idx[2]];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit update closest hit distance and index
+                        if (f < t_max)
+                        {
+                            hits[global_id] = HIT_MARKER;
+                            return;
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {
@@ -297,19 +302,26 @@ KERNEL void intersect_main(
                 if (LEAFNODE(node))
                 {
                     Face face = faces[STARTIDX(node)];
-                    // Leafs directly store vertex indices
-                    // so we load vertices directly
-                    float3 const v1 = vertices[face.idx[0]];
-                    float3 const v2 = vertices[face.idx[1]];
-                    float3 const v3 = vertices[face.idx[2]];
-                    // Intersect triangle
-                    float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
-                    // If hit update closest hit distance and index
-                    if (f < t_max)
+#ifdef RR_RAY_MASK
+                    if (ray_get_mask(&r) != face.shape_id)
                     {
-                        t_max = f;
-                        isect_idx = STARTIDX(node);
+#endif
+                        // Leafs directly store vertex indices
+                        // so we load vertices directly
+                        float3 const v1 = vertices[face.idx[0]];
+                        float3 const v2 = vertices[face.idx[1]];
+                        float3 const v3 = vertices[face.idx[2]];
+                        // Intersect triangle
+                        float const f = fast_intersect_triangle(r, v1, v2, v3, t_max);
+                        // If hit update closest hit distance and index
+                        if (f < t_max)
+                        {
+                            t_max = f;
+                            isect_idx = STARTIDX(node);
+                        }
+#ifdef RR_RAY_MASK
                     }
+#endif
                 }
                 else
                 {

--- a/RadeonRays/src/primitive/instance.h
+++ b/RadeonRays/src/primitive/instance.h
@@ -46,11 +46,11 @@ namespace RadeonRays
         Shape const* GetBaseShape() const;
 
         // Instance flag
-        bool is_instance() const;
+        bool is_instance() const override;
     private:
         /// Disallow to copy meshes, too heavy
-        Instance(Instance const& o);
-        Instance& operator = (Instance const& o);
+        Instance(Instance const& o) = delete;
+        Instance& operator = (Instance const& o) = delete;
 
         /// Base shape
         Shape const* shape_;

--- a/RadeonRays/src/primitive/mesh.cpp
+++ b/RadeonRays/src/primitive/mesh.cpp
@@ -142,7 +142,4 @@ namespace RadeonRays
         }
     }
 
-    Mesh::~Mesh()
-    {
-    }
 }

--- a/RadeonRays/src/primitive/mesh.h
+++ b/RadeonRays/src/primitive/mesh.h
@@ -70,7 +70,7 @@ namespace RadeonRays
             int nfaces);
         
         //
-        ~Mesh();
+        ~Mesh() = default;
         //
         int num_faces() const;
         //
@@ -86,8 +86,8 @@ namespace RadeonRays
 
     private:
         /// Disallow to copy meshes, too heavy
-        Mesh(Mesh const& o);
-        Mesh& operator = (Mesh const& o);
+        Mesh(Mesh const& o) = delete;
+        Mesh& operator = (Mesh const& o) = delete;
 
         // transforms face vertices, outverts but be at least 4 float3 in size, no of vertices in face returned
         int GetTransformedFace(int const faceidx, matrix const & transform, float3* outverts) const;

--- a/RadeonRays/src/primitive/shapeimpl.h
+++ b/RadeonRays/src/primitive/shapeimpl.h
@@ -76,12 +76,6 @@ namespace RadeonRays
         
         // Get ID
         Id GetId() const override;
-
-        // Set intersection mask 
-        void SetMask(int mask) override;
-
-        // Get intersection mask
-        int  GetMask() const override;
         
         // Get state changes since last OnCommit
         int GetStateChange() const;
@@ -95,7 +89,6 @@ namespace RadeonRays
         matrix worldmatinv_;
         float3 linearmotion_;
         quaternion angulrmotion_;
-        int mask_;
         // Id
         Id id_;
         // State change
@@ -104,7 +97,6 @@ namespace RadeonRays
 
     inline ShapeImpl::ShapeImpl()
     {
-        SetMask(0xFFFFFFFF);
     }
 
     inline ShapeImpl::~ShapeImpl()
@@ -170,17 +162,6 @@ namespace RadeonRays
     inline bool ShapeImpl::is_instance() const
     {
         return false;
-    }
-
-    inline void ShapeImpl::SetMask(int mask)
-    {
-        mask_ = mask;
-        statechange_ |= kStateChangeMask;
-    }
-
-    inline int  ShapeImpl::GetMask() const
-    {
-        return mask_;
     }
 }
 

--- a/RadeonRays/src/primitive/shapeimpl.h
+++ b/RadeonRays/src/primitive/shapeimpl.h
@@ -45,10 +45,10 @@ namespace RadeonRays
         };
         
         // Constructor
-        ShapeImpl();
+        ShapeImpl() = default;
 
         // Destructor
-        ~ShapeImpl() = 0;
+        ~ShapeImpl() = default;
 
         // This is needed since instances need special API handling
         virtual bool is_instance() const;
@@ -94,14 +94,6 @@ namespace RadeonRays
         // State change
         mutable int statechange_;
     };
-
-    inline ShapeImpl::ShapeImpl()
-    {
-    }
-
-    inline ShapeImpl::~ShapeImpl()
-    {
-    }
     
     inline void ShapeImpl::SetTransform(matrix const& m, matrix const& minv)
     {

--- a/RadeonRays/src/translator/fatnode_bvh_translator.cpp
+++ b/RadeonRays/src/translator/fatnode_bvh_translator.cpp
@@ -79,7 +79,6 @@ namespace RadeonRays
                 node.s1.i2 = faces[idx].idx[2];
                 node.s1.shape_id = faces[idx].shapeidx;
                 node.s1.prim_id = faces[idx].id;
-                node.s1.shape_mask = faces[idx].shape_mask;
             }
         }
     }

--- a/RadeonRays/src/translator/fatnode_bvh_translator.h
+++ b/RadeonRays/src/translator/fatnode_bvh_translator.h
@@ -54,11 +54,7 @@ namespace RadeonRays
         };
 
         // Constructor
-        FatNodeBvhTranslator()
-            : nodecnt_(0)
-            , root_(0)
-        {
-        }
+        FatNodeBvhTranslator() = default;
 
         // Fat BVH node
         // Encoding:
@@ -107,8 +103,8 @@ namespace RadeonRays
         std::vector<int> roots_;
         std::vector<int> indices_;
         std::vector<int> addresses_;
-        int nodecnt_;
-        int root_;
+        int nodecnt_ = 0;
+        int root_ = 0;
         std::unique_ptr<PerfectHashMap<int, int>> m_hash_map;
         int max_idx_;
 
@@ -116,8 +112,8 @@ namespace RadeonRays
         int ProcessRootNode(Bvh::Node const* node);
         //int ProcessNode(Bvh::Node const* n, int offset);
 
-        FatNodeBvhTranslator(FatNodeBvhTranslator const&);
-        FatNodeBvhTranslator& operator =(FatNodeBvhTranslator const&);
+        FatNodeBvhTranslator(FatNodeBvhTranslator const&) = delete;
+        FatNodeBvhTranslator& operator =(FatNodeBvhTranslator const&) = delete;
     };
 }
 

--- a/RadeonRays/src/translator/fatnode_bvh_translator.h
+++ b/RadeonRays/src/translator/fatnode_bvh_translator.h
@@ -51,8 +51,6 @@ namespace RadeonRays
             int shapeidx;
             // Primitive ID within the mesh
             int id;
-            // Shape mask
-            int shape_mask;
         };
 
         // Constructor
@@ -82,8 +80,6 @@ namespace RadeonRays
                     int i0, i1, i2;
                     // Address of a left child
                     int child0;
-                    // Shape mask
-                    int shape_mask;
                     // Shape ID
                     int shape_id;
                     // Primitive ID

--- a/RadeonRays/src/translator/plain_bvh_translator.h
+++ b/RadeonRays/src/translator/plain_bvh_translator.h
@@ -40,11 +40,7 @@ namespace RadeonRays
     {
     public:
         // Constructor
-        PlainBvhTranslator()
-            : nodecnt_(0)
-            , root_(0)
-        {
-        }
+        PlainBvhTranslator() = default;
 
         // Plain BVH node
         struct Node
@@ -61,15 +57,15 @@ namespace RadeonRays
         std::vector<Node> nodes_;
         std::vector<int>  extra_;
         std::vector<int>  roots_;
-        int nodecnt_;
-        int root_;
+        int nodecnt_ = 0;
+        int root_ = 0;
 
     private:
         int ProcessNode(Bvh::Node const* node);
         int ProcessNode(Bvh::Node const* n, int offset);
 
-        PlainBvhTranslator(PlainBvhTranslator const&);
-        PlainBvhTranslator& operator =(PlainBvhTranslator const&);
+        PlainBvhTranslator(PlainBvhTranslator const&) = delete;
+        PlainBvhTranslator& operator =(PlainBvhTranslator const&) = delete;
     };
 }
 

--- a/RadeonRays/src/translator/q_bvh_translator.h
+++ b/RadeonRays/src/translator/q_bvh_translator.h
@@ -60,9 +60,7 @@ namespace RadeonRays
         };
 
         // Constructor
-        QBvhTranslator()
-        {
-        }
+        QBvhTranslator() = default;
 
         void Process(const Bvh2 &bvh);
 

--- a/RadeonRays/src/util/alignedalloc.h
+++ b/RadeonRays/src/util/alignedalloc.h
@@ -45,17 +45,17 @@ namespace RadeonRays {
         typedef const T&  const_reference;
         typedef T         value_type;
 #endif
-        typedef typename std::allocator<T>::size_type size_type;
-        typedef typename std::allocator<T>::pointer pointer;
-        typedef typename std::allocator<T>::const_pointer const_pointer;
+        using size_type = typename std::allocator<T>::size_type;
+        using pointer = typename std::allocator<T>::pointer;
+        using const_pointer = typename std::allocator<T>::const_pointer;
 
         /// Defines an aligned allocator suitable for allocating elements of type
         /// @c U.
         template <class U>
-        struct rebind { typedef aligned_allocator<U, Alignment> other; };
+        struct rebind { using other = aligned_allocator<U, Alignment>; };
 
         /// Default-constructs an allocator.
-        aligned_allocator() throw() { }
+        aligned_allocator() throw() = default;
 
         /// Copy-constructs an allocator.
         aligned_allocator(const aligned_allocator& other) throw()
@@ -66,7 +66,7 @@ namespace RadeonRays {
         aligned_allocator(const aligned_allocator<U, Alignment>&) throw() { }
 
         /// Destroys an allocator.
-        ~aligned_allocator() throw() { }
+        ~aligned_allocator() throw() = default;
 
         /// Allocates @c n elements of type @c T, aligned to a multiple of
         /// @c Alignment.

--- a/RadeonRays/src/util/options.h
+++ b/RadeonRays/src/util/options.h
@@ -69,7 +69,7 @@ namespace RadeonRays
         };
 
         // Constructor
-        Options(){}
+        Options() = default;
 
         // Set string value
         void SetValue(std::string const& name, std::string const& value);

--- a/RadeonRays/src/util/progressreporter.h
+++ b/RadeonRays/src/util/progressreporter.h
@@ -31,7 +31,7 @@ namespace RadeonRays
     {
     public:
         // Destructor
-        virtual ~ProgressReporter(){}
+        virtual ~ProgressReporter() = default;
         // Progress callback: pass current progress in percents.
         // The caller decides on the resolution, but reporter 
         // is free to coarsen it

--- a/RadeonRays/src/world/world.cpp
+++ b/RadeonRays/src/world/world.cpp
@@ -54,9 +54,9 @@ namespace RadeonRays
     {
         int statechange_ = ShapeImpl::kStateChangeNone;
 
-        for (auto iter = shapes_.cbegin(); iter != shapes_.cend(); ++iter)
+        for (auto shape : shapes_)
         {
-            ShapeImpl const* shapeimpl = static_cast<ShapeImpl const*>(*iter);
+            ShapeImpl const* shapeimpl = static_cast<ShapeImpl const*>(shape);
 
             statechange_ |= shapeimpl->GetStateChange();
         }
@@ -66,9 +66,9 @@ namespace RadeonRays
 
     void World::OnCommit()
     {
-        for (auto iter = shapes_.cbegin(); iter != shapes_.cend(); ++iter)
+        for (auto shape : shapes_)
         {
-            auto shapeimpl = static_cast<ShapeImpl const*>(*iter);
+            auto shapeimpl = static_cast<ShapeImpl const*>(shape);
 
             shapeimpl->OnCommit();
         }

--- a/RadeonRays/src/world/world.h
+++ b/RadeonRays/src/world/world.h
@@ -39,9 +39,9 @@ namespace RadeonRays
     {
     public:
         //
-        World();
+        World() = default;
         //
-        virtual ~World();
+        virtual ~World() = default;
         // Attach the shape updating all the flags
         void AttachShape(Shape const* shape);
         // Detach the shape 
@@ -63,21 +63,12 @@ namespace RadeonRays
         std::vector<int> shapes_dirty_;
 
         // TODO: Do more preciese dirty flags tracking
-        bool has_changed_;
+        bool has_changed_ = true;
         // Global flags
         int hint_;
         // Options
         Options options_;
     };
-
-    inline World::World()
-        : has_changed_(true)
-    {
-    }
-
-    inline World::~World()
-    {
-    }
 
     inline bool World::has_changed() const
     {

--- a/UnitTest/CMakeLists.txt
+++ b/UnitTest/CMakeLists.txt
@@ -75,3 +75,7 @@ endif (RR_USE_VULKAN)
 if (RR_ENABLE_RAYMASK) 
     target_compile_definitions(UnitTest PRIVATE RR_RAY_MASK)
 endif (RR_ENABLE_RAYMASK)
+
+if (RR_ENABLE_BACKFACE_CULL)
+    target_compile_definitions(UnitTest PRIVATE RR_BACKFACE_CULL)
+endif (RR_ENABLE_BACKFACE_CULL)

--- a/UnitTest/calc_test_cl.h
+++ b/UnitTest/calc_test_cl.h
@@ -44,12 +44,12 @@ THE SOFTWARE.
 class CalcTestkOpenCL : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         m_calc = CreateCalc(Calc::Platform::kOpenCL, 0);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         DeleteCalc(m_calc);
     }

--- a/UnitTest/clw_test.h
+++ b/UnitTest/clw_test.h
@@ -47,6 +47,21 @@ public:
         // Create all available platforms
         CLWPlatform::CreateAllPlatforms(platforms);
 
+        // Remove platforms that don't have any associated devices
+        for (auto it = platforms.begin(); it != platforms.end();)
+        {
+            if (it->GetDeviceCount() == 0)
+            {
+                it = platforms.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        ThrowIf(platforms.empty(), CL_DEVICE_NOT_FOUND, "CLW::SetUp failed => no available OpenCL platforms with at least 1 device!");
+
         // Try to find AMD platform and set a flag if found
         bool       amdctx_ = false;
         for (int i = 0; i < platforms.size(); ++i)

--- a/UnitTest/clw_test.h
+++ b/UnitTest/clw_test.h
@@ -40,7 +40,7 @@ THE SOFTWARE.
 class CLW : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         std::vector<CLWPlatform> platforms;
 
@@ -64,12 +64,12 @@ public:
 
         // Try to find AMD platform and set a flag if found
         bool       amdctx_ = false;
-        for (int i = 0; i < platforms.size(); ++i)
+        for (auto & platform : platforms)
         {
-            if (platforms[i].GetVendor().find("AMD") != std::string::npos ||
-                platforms[i].GetVendor().find("Advanced Micro Devices") != std::string::npos)
+            if (platform.GetVendor().find("AMD") != std::string::npos ||
+                platform.GetVendor().find("Advanced Micro Devices") != std::string::npos)
             {
-                context_ = CLWContext::Create(platforms[i].GetDevice(0));
+                context_ = CLWContext::Create(platform.GetDevice(0));
                 amdctx_ = true;
             }
         }
@@ -97,7 +97,7 @@ public:
                          );
     }
     
-    virtual void TearDown()
+    void TearDown() override
     {
     }
     
@@ -175,7 +175,7 @@ TEST_F(CLW, BufferWrite)
 TEST_F(CLW, ExclusiveScanSmall)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
     // Small array test
     int arraysize = 111;
 
@@ -221,7 +221,7 @@ TEST_F(CLW, ExclusiveScanSmall)
 TEST_F(CLW, ExclusiveScanSmallSizeDifference)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
     // Small array test
     int arraysize = 4096;
 
@@ -267,7 +267,7 @@ TEST_F(CLW, ExclusiveScanSmallSizeDifference)
 TEST_F(CLW, ExclusiveScanLarge)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
     // Large array test
     int arraysize = 13820049;
 
@@ -313,7 +313,7 @@ TEST_F(CLW, ExclusiveScanLarge)
 TEST_F(CLW, ExclusiveScanRandom)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
 
     for (int i = 0; i < 10; ++i)
     {
@@ -362,7 +362,7 @@ TEST_F(CLW, ExclusiveScanRandom)
 TEST_F(CLW, CompactIdentity)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
     // Small array test
     int arraysize = 480021;
 
@@ -409,7 +409,7 @@ TEST_F(CLW, CompactIdentity)
 TEST_F(CLW, RadixSortLarge)
 {
     // Init rand
-    std::srand((unsigned)std::time(0));
+    std::srand((unsigned)std::time(nullptr));
     // Large array test
     int arraysize = 64237846;
 

--- a/UnitTest/clw_test_cl.h
+++ b/UnitTest/clw_test_cl.h
@@ -46,7 +46,7 @@ THE SOFTWARE.
 class CLWCL : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         cl_int status = CL_SUCCESS;
         cl_platform_id platform;
@@ -80,7 +80,7 @@ public:
         ASSERT_NO_THROW(context_ = CLWContext::Create(rawcontext_, &device, &queue_, 1));
     }
     
-    virtual void TearDown()
+    void TearDown() override
     {
         clReleaseCommandQueue(queue_);
         clReleaseContext(rawcontext_);

--- a/UnitTest/radeon_rays_apitest_cl.h
+++ b/UnitTest/radeon_rays_apitest_cl.h
@@ -38,7 +38,7 @@ using namespace RadeonRays;
 class ApiBackendOpenCL : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         api_ = nullptr;
         int nativeidx = -1;
@@ -62,7 +62,7 @@ public:
         api_ = IntersectionApi::Create(nativeidx);
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         if(api_ != nullptr) IntersectionApi::Delete(api_);
     }
@@ -760,11 +760,11 @@ TEST_F(ApiBackendOpenCL, CornellBoxLoad)
     ASSERT_NO_THROW(api_->SetOption("acc.type", "grid"));
 
     // Create meshes within IntersectionApi
-    for  (int i=0; i<(int)shapes.size(); ++i)
+    for  (auto & tObjShape : shapes)
     {
         Shape* shape = nullptr;
-        ASSERT_NO_THROW(shape = api_->CreateMesh(&shapes[i].mesh.positions[0], (int)shapes[i].mesh.positions.size() / 3, 3*sizeof(float),
-            &shapes[i].mesh.indices[0], 0, nullptr, (int)shapes[i].mesh.indices.size() / 3));
+        ASSERT_NO_THROW(shape = api_->CreateMesh(&tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size() / 3, 3*sizeof(float),
+            &tObjShape.mesh.indices[0], 0, nullptr, (int)tObjShape.mesh.indices.size() / 3));
 
         ASSERT_NO_THROW(api_->AttachShape(shape));
         apishapes.push_back(shape);
@@ -774,9 +774,9 @@ TEST_F(ApiBackendOpenCL, CornellBoxLoad)
     ASSERT_NO_THROW(api_->Commit());
 
     // Delete meshes
-    for (int i=0; i<(int)apishapes.size(); ++i)
+    for (auto & apishape : apishapes)
     {
-        ASSERT_NO_THROW(api_->DeleteShape(apishapes[i]));
+        ASSERT_NO_THROW(api_->DeleteShape(apishape));
     }
 }
 
@@ -793,11 +793,11 @@ TEST_F(ApiBackendOpenCL, CornellBox_1Ray)
     //ASSERT_NO_THROW(api_->SetOption("acc.type", "grid"));
 
     // Create meshes within IntersectionApi
-    for (int i = 0; i<(int)shapes.size(); ++i)
+    for (auto & tObjShape : shapes)
     {
         Shape* shape = nullptr;
-        ASSERT_NO_THROW(shape = api_->CreateMesh(&shapes[i].mesh.positions[0], (int)shapes[i].mesh.positions.size() / 3, 3 * sizeof(float),
-            &shapes[i].mesh.indices[0], 0, nullptr, (int)shapes[i].mesh.indices.size() / 3));
+        ASSERT_NO_THROW(shape = api_->CreateMesh(&tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size() / 3, 3 * sizeof(float),
+            &tObjShape.mesh.indices[0], 0, nullptr, (int)tObjShape.mesh.indices.size() / 3));
 
         ASSERT_NO_THROW(api_->AttachShape(shape));
         apishapes.push_back(shape);
@@ -830,9 +830,9 @@ TEST_F(ApiBackendOpenCL, CornellBox_1Ray)
 
 
     // Delete meshes
-    for (int i = 0; i<(int)apishapes.size(); ++i)
+    for (auto & apishape : apishapes)
     {
-        ASSERT_NO_THROW(api_->DeleteShape(apishapes[i]));
+        ASSERT_NO_THROW(api_->DeleteShape(apishape));
     }
 
     ASSERT_NO_THROW(api_->DeleteBuffer(ray_buffer));
@@ -1170,7 +1170,7 @@ void ApiBackendOpenCL::Perform_1Ray_Masked_Test()
     // Set mesh Id
     ASSERT_NO_THROW(mesh2->SetId(10));
 
-    // Attach the mesh to the scene
+    // Attach mesh2 to the scene
     ASSERT_NO_THROW(api_->AttachShape(mesh2));
 
     // Prepare the ray
@@ -1225,7 +1225,7 @@ void ApiBackendOpenCL::Perform_1Ray_Masked_Test()
 
     mesh->SetId(1);
 
-    // Attach the mesh to the scene
+    // Detach mesh2 from the scene
     ASSERT_NO_THROW(api_->DetachShape(mesh2));
 
     int result = kNullId;
@@ -1270,6 +1270,7 @@ void ApiBackendOpenCL::Perform_1Ray_Masked_Test()
     // Bail out
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+    ASSERT_NO_THROW(api_->DeleteShape(mesh2));
     ASSERT_NO_THROW(api_->DeleteBuffer(ray_buffer));
     ASSERT_NO_THROW(api_->DeleteBuffer(isect_buffer));
     ASSERT_NO_THROW(api_->DeleteBuffer(isect_flag_buffer));

--- a/UnitTest/radeon_rays_apitest_cl.h
+++ b/UnitTest/radeon_rays_apitest_cl.h
@@ -256,6 +256,7 @@ TEST_F(ApiBackendOpenCL, DISABLED_Intersection_1Ray_Masked)
     Shape* mesh = nullptr;
 
     api_->SetOption("acc.type", "bvh");
+    api_->SetOption("bvh.force2level", 1.f);
 
     // Create mesh
     ASSERT_NO_THROW(mesh = api_->CreateMesh(vertices(), 3, 3 * sizeof(float), indices(), 0, numfaceverts(), 1));

--- a/UnitTest/radeon_rays_conformance_test_cl.h
+++ b/UnitTest/radeon_rays_conformance_test_cl.h
@@ -118,27 +118,27 @@ inline void ApiConformanceCL::SetUp()
     std::string res = LoadObj(shapes_, materials_, "../Resources/CornellBox/orig.objm");
 
     // Create meshes within IntersectionApi
-    for (int i = 0; i<(int)shapes_.size(); ++i)
+    for (auto & tObjShape : shapes_)
     {
         Shape* shape = nullptr;
 
         if( apicpu_ != nullptr )
         {
-            EXPECT_NO_THROW(shape = apicpu_->CreateMesh(&shapes_[i].mesh.positions[0], (int)shapes_[i].mesh.positions.size() / 3, 3 * sizeof(float),
-                &shapes_[i].mesh.indices[0], 0, nullptr, (int)shapes_[i].mesh.indices.size() / 3));
+            EXPECT_NO_THROW(shape = apicpu_->CreateMesh(&tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size() / 3, 3 * sizeof(float),
+                &tObjShape.mesh.indices[0], 0, nullptr, (int)tObjShape.mesh.indices.size() / 3));
 
             EXPECT_NO_THROW(apicpu_->AttachShape(shape));
 
             apishapes_cpu_.push_back(shape);
         }
 
-        EXPECT_NO_THROW(shape = apigpu_->CreateMesh(&shapes_[i].mesh.positions[0], (int)shapes_[i].mesh.positions.size() / 3, 3 * sizeof(float),
-            &shapes_[i].mesh.indices[0], 0, nullptr, (int)shapes_[i].mesh.indices.size() / 3));
+        EXPECT_NO_THROW(shape = apigpu_->CreateMesh(&tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size() / 3, 3 * sizeof(float),
+            &tObjShape.mesh.indices[0], 0, nullptr, (int)tObjShape.mesh.indices.size() / 3));
 
         EXPECT_NO_THROW(apigpu_->AttachShape(shape));
 
-        test_shapes_.push_back({ &shapes_[i].mesh.positions[0], (int)shapes_[i].mesh.positions.size() / 3,
-            &shapes_[i].mesh.indices[0], (int)shapes_[i].mesh.indices.size(), nullptr, (int)shapes_[i].mesh.indices.size() / 3 });
+        test_shapes_.emplace_back( &tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size() / 3,
+            &tObjShape.mesh.indices[0], (int)tObjShape.mesh.indices.size(), nullptr, (int)tObjShape.mesh.indices.size() / 3 );
         test_shapes_.back().shape = shape;
 
         apishapes_gpu_.push_back(shape);
@@ -443,10 +443,10 @@ TEST_F(ApiConformanceCL, DISABLED_CornellBox_10000RaysRandom_ClosestHit_Events_B
     ray r_brute[kNumRays];
 
     // generate some random vectors
-    for (int i = 0; i < kNumRays; ++i)
+    for (auto & ray : r_brute)
     {
-        r_brute[i].o = float3(rand_float() * 3.f - 1.5f, rand_float() * 3.f - 1.5f, rand_float() * 3.f - 1.5f, 1000.f);
-        r_brute[i].d = normalize(float3(rand_float(), rand_float(), rand_float()));
+        ray.o = float3(rand_float() * 3.f - 1.5f, rand_float() * 3.f - 1.5f, rand_float() * 3.f - 1.5f, 1000.f);
+        ray.d = normalize(float3(rand_float(), rand_float(), rand_float()));
     }
 
     EXPECT_NO_THROW(apicpu_->Commit());

--- a/UnitTest/radeon_rays_conformance_test_cl.h
+++ b/UnitTest/radeon_rays_conformance_test_cl.h
@@ -475,8 +475,10 @@ TEST_F(ApiConformanceCL, DISABLED_CornellBox_10000RaysRandom_ClosestHit_Events_B
         r_gpu[i].d = r_cpu[i].d = r_brute[i].d;
         r_gpu[i].SetActive(true);
         r_cpu[i].SetActive(true);
-        r_gpu[i].SetMask(0xFFFFFFFF);
-        r_cpu[i].SetMask(0xFFFFFFFF);
+        r_gpu[i].SetMask(-1);
+        r_cpu[i].SetMask(-1);
+        r_gpu[i].SetDoBackfaceCulling(false);
+        r_cpu[i].SetDoBackfaceCulling(false);
     }
 
     EXPECT_NO_THROW(apicpu_->UnmapBuffer(ray_buffer_cpu, r_cpu, &ecpu));
@@ -577,7 +579,8 @@ inline void ApiConformanceCL::ExpectClosestRaysOk(RadeonRays::IntersectionApi* a
         rays[i].d = r_brute[i].d;
 
         rays[i].SetActive(true);
-        rays[i].SetMask(0xFFFFFFFF);
+        rays[i].SetMask(-1);
+        rays[i].SetDoBackfaceCulling(false);
     }
 
     EXPECT_NO_THROW(api->UnmapBuffer(ray_buffer, rays, &ev));
@@ -644,7 +647,8 @@ inline void ApiConformanceCL::ExpectAnyRaysOk(RadeonRays::IntersectionApi* api) 
         rays[i].d = r_brute[i].d;
 
         rays[i].SetActive(true);
-        rays[i].SetMask(0xFFFFFFFF);
+        rays[i].SetMask(-1);
+        rays[i].SetDoBackfaceCulling(false);
     }
 
     EXPECT_NO_THROW(api->UnmapBuffer(ray_buffer, rays, &ev));

--- a/UnitTest/radeon_rays_performance_test_cl.h
+++ b/UnitTest/radeon_rays_performance_test_cl.h
@@ -75,7 +75,7 @@ public:
         queue_ = clCreateCommandQueue(rawcontext_, device, 0, &status);
         ASSERT_EQ(status, CL_SUCCESS);
 
-        ASSERT_NO_THROW(api_ = IntersectionApiCL::CreateFromOpenClContext(rawcontext_, device, queue_));
+        ASSERT_NO_THROW(api_ = RadeonRays::CreateFromOpenClContext(rawcontext_, device, queue_));
 
         // Load obj file 
         std::string res = LoadObj(shapes_, materials_, "../Resources/bmw/i8.obj");

--- a/UnitTest/radeon_rays_performance_test_cl.h
+++ b/UnitTest/radeon_rays_performance_test_cl.h
@@ -47,7 +47,7 @@ using namespace tinyobj;
 class ApiPerformance : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         cl_int status = CL_SUCCESS;
         cl_platform_id platform;
@@ -81,12 +81,12 @@ public:
         std::string res = LoadObj(shapes_, materials_, "../Resources/bmw/i8.obj");
 
         // Create meshes within IntersectionApi
-        for  (int i=0; i<(int)shapes_.size(); ++i)
+        for (auto & tObjShape : shapes_)
         {
             Shape* shape = nullptr;
 
-            ASSERT_NO_THROW(shape = api_->CreateMesh(&shapes_[i].mesh.positions[0], (int)shapes_[i].mesh.positions.size(), 3*sizeof(float),
-                &shapes_[i].mesh.indices[0], 0, nullptr, (int)shapes_[i].mesh.indices.size() / 3));
+            ASSERT_NO_THROW(shape = api_->CreateMesh(&tObjShape.mesh.positions[0], (int)tObjShape.mesh.positions.size(), 3*sizeof(float),
+                &tObjShape.mesh.indices[0], 0, nullptr, (int)tObjShape.mesh.indices.size() / 3));
 
             ASSERT_NO_THROW(api_->AttachShape(shape));
 
@@ -94,12 +94,12 @@ public:
         }
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
         // Delete meshes
-        for (int i=0; i<(int)apishapes_.size(); ++i)
+        for (auto & apishape : apishapes_)
         {
-            ASSERT_NO_THROW(api_->DeleteShape(apishapes_[i]));
+            ASSERT_NO_THROW(api_->DeleteShape(apishape));
         }
 
         IntersectionApi::Delete(api_);

--- a/UnitTest/radeon_rays_test_cl.h
+++ b/UnitTest/radeon_rays_test_cl.h
@@ -112,8 +112,8 @@ TEST_F(ApiCl, Intersection_1Ray)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
         
     };
     
@@ -197,8 +197,8 @@ TEST_F(ApiCl, Intersection_1Ray_Buffer)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
         
     };
     
@@ -268,8 +268,8 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
     };
     
     // Indices
@@ -347,8 +347,8 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer_Indirect)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
         
     };
     
@@ -434,8 +434,8 @@ TEST_F(ApiCl, Intersection_Events)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
         
     };
     
@@ -514,8 +514,8 @@ TEST_F(ApiCl, Intersection_DependencyEvents)
     // Mesh vertices
     float vertices[] = {
         -1.f,-1.f,0.f,
-        1.f,-1.f,0.f,
         0.f,1.f,0.f,
+        1.f,-1.f,0.f,
         
     };
     

--- a/UnitTest/radeon_rays_test_cl.h
+++ b/UnitTest/radeon_rays_test_cl.h
@@ -189,6 +189,10 @@ TEST_F(ApiCl, ClBuffer)
     ASSERT_NO_THROW(apibuffer = RadeonRays::CreateFromOpenClBuffer(api_,buffer));
     
     ASSERT_NO_THROW(api_->DeleteBuffer(apibuffer));
+
+    status = clReleaseMemObject(buffer);
+
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 // The test creates a single triangle mesh and tests attach/detach functionality
@@ -259,6 +263,12 @@ TEST_F(ApiCl, Intersection_1Ray_Buffer)
     ASSERT_NO_THROW(api_->DeleteBuffer(hitinfos));
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+
+    status = clReleaseMemObject(rays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(hitinfos_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 
@@ -311,7 +321,6 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer)
     ASSERT_EQ(status, CL_SUCCESS);
     
     Buffer* rays = nullptr;
-    Buffer* hits = nullptr;
     Buffer* hitinfos = nullptr;
     
     // Create API objects
@@ -335,10 +344,15 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer)
     
     // Bail out
     ASSERT_NO_THROW(api_->DeleteBuffer(rays));
-    ASSERT_NO_THROW(api_->DeleteBuffer(hits));
     ASSERT_NO_THROW(api_->DeleteBuffer(hitinfos));
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+
+    status = clReleaseMemObject(rays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(hitinfos_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 // The test creates a single triangle mesh and tests attach/detach functionality
@@ -395,7 +409,6 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer_Indirect)
     ASSERT_EQ(status, CL_SUCCESS);
 
     Buffer* rays = nullptr;
-    Buffer* hits = nullptr;
     Buffer* hitinfos = nullptr;
     Buffer* numrays = nullptr;
 
@@ -421,10 +434,19 @@ TEST_F(ApiCl, Intersection_3Rays_Buffer_Indirect)
     
     // Bail out
     ASSERT_NO_THROW(api_->DeleteBuffer(rays));
-    ASSERT_NO_THROW(api_->DeleteBuffer(hits));
     ASSERT_NO_THROW(api_->DeleteBuffer(hitinfos));
+    ASSERT_NO_THROW(api_->DeleteBuffer(numrays));
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+
+    status = clReleaseMemObject(rays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(hitinfos_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(numrays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 
@@ -505,6 +527,12 @@ TEST_F(ApiCl, Intersection_Events)
     ASSERT_NO_THROW(api_->DeleteBuffer(hitinfos));
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+
+    status = clReleaseMemObject(rays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(hitinfos_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 
@@ -592,6 +620,12 @@ TEST_F(ApiCl, Intersection_DependencyEvents)
     ASSERT_NO_THROW(api_->DeleteBuffer(hitinfos));
     ASSERT_NO_THROW(api_->DetachShape(mesh));
     ASSERT_NO_THROW(api_->DeleteShape(mesh));
+
+    status = clReleaseMemObject(rays_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
+
+    status = clReleaseMemObject(hitinfos_buffer);
+    ASSERT_EQ(status, CL_SUCCESS);
 }
 
 #endif // USE_OPENCL

--- a/UnitTest/radeon_rays_test_cl.h
+++ b/UnitTest/radeon_rays_test_cl.h
@@ -48,7 +48,7 @@ using namespace RadeonRays;
 class ApiCl : public ::testing::Test
 {
 public:
-    virtual void SetUp()
+    void SetUp() override
     {
         cl_int status = CL_SUCCESS;
         cl_platform_id platform[2];
@@ -92,7 +92,7 @@ public:
         //}
     }
     
-    virtual void TearDown()
+    void TearDown() override
     {
         IntersectionApi::Delete(api_);
         clReleaseCommandQueue(queue_);

--- a/UnitTest/tiny_obj_loader.cpp
+++ b/UnitTest/tiny_obj_loader.cpp
@@ -34,7 +34,7 @@ namespace tinyobj {
 
 struct vertex_index {
   int v_idx, vt_idx, vn_idx;
-  vertex_index() {};
+  vertex_index() = default;
   vertex_index(int idx) : v_idx(idx), vt_idx(idx), vn_idx(idx) {};
   vertex_index(int vidx, int vtidx, int vnidx) : v_idx(vidx), vt_idx(vtidx), vn_idx(vnidx) {};
 
@@ -243,9 +243,7 @@ exportFaceGroupToShape(
   offset = shape.mesh.indices.size();
 
   // Flatten vertices and indices
-  for (size_t i = 0; i < faceGroup.size(); i++) {
-    const std::vector<vertex_index>& face = faceGroup[i];
-
+  for (const std::vector<vertex_index>& face : faceGroup) {
     vertex_index i0 = face[0];
     vertex_index i1(-1);
     vertex_index i2 = face[1];
@@ -297,10 +295,10 @@ std::string LoadMtl (
     std::string linebuf(&buf[0]);
 
     // Trim newline '\r\n' or '\n'
-    if (linebuf.size() > 0) {
+    if (!linebuf.empty()) {
       if (linebuf[linebuf.size()-1] == '\n') linebuf.erase(linebuf.size()-1);
     }
-    if (linebuf.size() > 0) {
+    if (!linebuf.empty()) {
       if (linebuf[linebuf.size()-1] == '\r') linebuf.erase(linebuf.size()-1);
     }
 
@@ -546,10 +544,10 @@ std::string LoadObj(
     std::string linebuf(&buf[0]);
 
     // Trim newline '\r\n' or '\n'
-    if (linebuf.size() > 0) {
+    if (!linebuf.empty()) {
       if (linebuf[linebuf.size()-1] == '\n') linebuf.erase(linebuf.size()-1);
     }
-    if (linebuf.size() > 0) {
+    if (!linebuf.empty()) {
       if (linebuf[linebuf.size()-1] == '\r') linebuf.erase(linebuf.size()-1);
     }
 

--- a/UnitTest/tiny_obj_loader.h
+++ b/UnitTest/tiny_obj_loader.h
@@ -52,8 +52,8 @@ typedef struct
 class MaterialReader
 {
 public:
-    MaterialReader(){}
-    virtual ~MaterialReader(){}
+    MaterialReader() = default;
+    virtual ~MaterialReader() = default;
 
     virtual std::string operator() (
         const std::string& matId,
@@ -66,11 +66,11 @@ class MaterialFileReader:
 {
     public:
         MaterialFileReader(const std::string& mtl_basepath): m_mtlBasePath(mtl_basepath) {}
-        virtual ~MaterialFileReader() {}
-        virtual std::string operator() (
+        virtual ~MaterialFileReader() = default;
+        std::string operator() (
           const std::string& matId,
           std::vector<material_t>& materials,
-          std::map<std::string, int>& matMap);
+          std::map<std::string, int>& matMap) override;
 
     private:
         std::string m_mtlBasePath;
@@ -85,7 +85,7 @@ std::string LoadObj(
     std::vector<shape_t>& shapes,   // [output]
     std::vector<material_t>& materials,   // [output]
     const char* filename,
-    const char* mtl_basepath = NULL);
+    const char* mtl_basepath = nullptr);
 
 /// Loads object from a std::istream, uses GetMtlIStreamFn to retrieve
 /// std::istream for materials.

--- a/UnitTest/utils.h
+++ b/UnitTest/utils.h
@@ -6,7 +6,7 @@ struct TestShape
     std::vector<float> positions;
     std::vector<int> indices;
     std::vector<int> faceverts;
-    RadeonRays::Shape* shape; //scene id
+    RadeonRays::Shape* shape = nullptr; //scene id
     
     TestShape(float const * vertices, int vnum,
         // Index data for vertices
@@ -15,14 +15,13 @@ struct TestShape
         int const * numfacevertices,
         // Number of faces
         int  numface)
-        : shape(nullptr)
     {
         positions.assign(vertices, vertices + 3*vnum);
         indices.assign(index, index + innum);
         if (numfacevertices)
             faceverts.assign(numfacevertices, numfacevertices + numface);
     }
-    TestShape() : shape(nullptr) {};
+    TestShape() = default;
 };
 
 // test functions, perform tests using unoptimised CPU for validating the fast paths


### PR DESCRIPTION
Hi,

these commits contain a new ray masking implementation (for all OpenCL intersection kernels) as well as a backface culling implementation (also for all OpenCL intersection kernels).
These new features are optional and are off by default. If either feature is disabled in CMake all code related to them is disabled at compile time to make sure that there is no performance impact.

For a more detailed description of the new features' implementation, please have a look at the commit messages.

I'd love to hear what you think, and if you have any feedback or would like something changed, please let me know.

Cheers,
Sebastian