### PR TITLE
Update Documentation page link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The library supports the following graphics and GPGPU frameworks as its backends
 
 RadeonRays requires a PC with the following software and hardware:
 
-- DirectX12: a 64-bit version of Windows® 10, and a GPU and drivers that supports DirectX12 features
-- Metal: a 64-bit version of MacOS® X 10.15 or later, and a discrete GPU that supports the MPS acceleration structure
-- Vulkan: a 64-bit version of Windows® 10 or Linux, and a GPU and drivers that support Vulkan version 1.2
+- DirectX12: a 64-bit version of WindowsÂ® 10, and a GPU and drivers that supports DirectX12 features
+- Metal: a 64-bit version of MacOSÂ® X 10.15 or later, and a discrete GPU that supports the MPS acceleration structure
+- Vulkan: a 64-bit version of WindowsÂ® 10 or Linux, and a GPU and drivers that support Vulkan version 1.2
 
 ## Documentation
 
-[Documentation page](https://radeon-pro.github.io/RadeonProRenderDocs/rr/about.html)
+[Documentation page](https://radeon-pro.github.io/RadeonProRenderDocs/en/rr/about.html)


### PR DESCRIPTION
Documentation link was stale and needed to include "/en/" in path for language.